### PR TITLE
Add multiconnect beta check

### DIFF
--- a/src/main/java/com/github/creeper123123321/viafabric/providers/VRVersionProvider.java
+++ b/src/main/java/com/github/creeper123123321/viafabric/providers/VRVersionProvider.java
@@ -58,9 +58,18 @@ public class VRVersionProvider extends VersionProvider {
                 Object mcApiInstance = mcApiClass.getMethod("instance").invoke(null);
                 List<?> protocols = (List<?>) mcApiClass.getMethod("getSupportedProtocols").invoke(mcApiInstance);
                 Method getValue = iProtocolClass.getMethod("getValue");
+                Method isMulticonnectBeta;
+                try {
+                    isMulticonnectBeta = iProtocolClass.getMethod("isMulticonnectBeta");
+                } catch (NoSuchMethodException e) {
+                    isMulticonnectBeta = null;
+                }
                 multiconnectSupportedVersions = new TreeSet<>();
                 for (Object protocol : protocols) {
-                    multiconnectSupportedVersions.add((Integer) getValue.invoke(protocol));
+                    // Do not use versions with beta multiconnect support, which may have stability issues
+                    if (isMulticonnectBeta == null || !(Boolean) isMulticonnectBeta.invoke(protocol)) {
+                        multiconnectSupportedVersions.add((Integer) getValue.invoke(protocol));
+                    }
                 }
                 ViaFabric.JLOGGER.info("ViaFabric will integrate with multiconnect");
             }


### PR DESCRIPTION
I added a new API in multiconnect to check if a protocol in beta support. ViaFabric should use this API if it exists, to avoid asking multiconnect to use this beta, which can have known stability issues.