### PR TITLE
Correct mod title.

### DIFF
--- a/viafabric-mc118/src/main/resources/fabric.mod.json
+++ b/viafabric-mc118/src/main/resources/fabric.mod.json
@@ -1,7 +1,7 @@
 {
   "schemaVersion": 1,
   "id": "viafabric-mc118",
-  "name": "ViaFabric for 1.17",
+  "name": "ViaFabric for 1.18",
   "version": "@version@",
   "description": "@description@",
   "license": "GPL-3.0",


### PR DESCRIPTION
Corrects a text string where 1.18's variant of ViaFabric mentions self as "for 1.17" instead, This pull request will fix that.