### PR TITLE
Replace HiveMC with minemen.

### DIFF
--- a/src/main/resources/assets/viafabric/config.yml
+++ b/src/main/resources/assets/viafabric/config.yml
@@ -9,4 +9,4 @@ hide-button: false
 # List of servers which ViaFabric will force disabling transforming on client-side. It can be overwritten by setting per-server version.
 # This isn't always the address in multiplayer GUI. It will use the SRV record pointer when present. Check the game log for the address.
 # Uses https://wiki.vg/Mojang_API#Blocked_Servers format (mc.example.com, *.example.com, 192.168.0.1, 192.168.*)
-client-side-force-disable: ["hypixel.net", "*.hypixel.net", "hivemc.com", "*.hivemc.com", "hivemc.eu", "*.hivemc.eu"]
+client-side-force-disable: ["hypixel.net", "*.hypixel.net", "minemen.club", "*.minemen.club"]


### PR DESCRIPTION
Replaces the HiveMC IPs with Minemen's IPs instead.

Reason A: HiveMC [Java version] has shut down since April 15th 2021 and now requires bedrock to join that server,
Reason B: Minemen has a very strict anti-cheat which can instantly ban players from using viafabric, in short being a similar case to [multiconnect's specific issue.](https://github.com/Earthcomputer/multiconnect/issues/197)