### PR TITLE
Update the client-side mode warning text.

### DIFF
--- a/src/main/resources/assets/viafabric/lang/en_us.json
+++ b/src/main/resources/assets/viafabric/lang/en_us.json
@@ -2,7 +2,7 @@
   "gui.protocol_version_field.name": "Protocol Version",
   "gui.enable_client_side_button": "Enable ViaVersion",
   "gui.enable_client_side.question": "Are you sure you want to enable client-side mode?",
-  "gui.enable_client_side.warning": "I cannot guarantee that this mod is allowed on every (or even any) server. This mod may cause problems with anti-cheat plugins. USE AT OWN RISK.",
+  "gui.enable_client_side.warning": "It cannot be guaranteed that this mod is allowed on specific servers as it can possibly cause problems with anti-cheat plugins. (USE ONLY WITH CAUTION!)",
   "gui.enable_client_side.enable": "Enable",
   "gui.viafabric_config.title": "ViaFabric Configurations",
   "gui.client_side.enable": "Enable client-side",


### PR DESCRIPTION
* Replaces the "i" section as it sounded like there was only one developer working for ViaFabric,
* Changes server section to read as "specific" as original text made it sound like every single server prohibits it instead,
* Changes the "use at own risk" to "use only with caution" to try and not scare players as a result.

Edits are welcome if changes need to be made.