### PR TITLE
Update config contexts.

### DIFF
--- a/src/main/resources/assets/viafabric/config.yml
+++ b/src/main/resources/assets/viafabric/config.yml
@@ -1,7 +1,7 @@
 # Disclaimer:
 #
 # It cannot be guaranteed that this mod is allowed on specific servers as it can possibly cause problems with anti-cheat plugins, (USE ONLY WITH CAUTION!)
-# This option enables client-side transforming (can also be enabled in-game)
+# This option enables client-side transforming. (can also be enabled in-game)
 enable-client-side: false
 # This option sets the protocol version to be used when connecting to servers. (can also be changed in-game)
 client-side-version: -1

--- a/src/main/resources/assets/viafabric/config.yml
+++ b/src/main/resources/assets/viafabric/config.yml
@@ -1,12 +1,14 @@
-# WARNING
-# I cannot guarantee that this mod is allowed on every (or even any) server. This mod may cause problems with anti cheat plugins. USE AT OWN RISK
+# Disclaimer:
+#
+# It cannot be guaranteed that this mod is allowed on specific servers as it can possibly cause problems with anti-cheat plugins, (USE ONLY WITH CAUTION!)
 # This option enables client-side transforming (can also be enabled in-game)
 enable-client-side: false
-# This option sets the protocol version to be used when connection to the server (can also be changed in-game)
+# This option sets the protocol version to be used when connecting to servers. (can also be changed in-game)
 client-side-version: -1
 # Hides VIA button from multiplayer menu.
 hide-button: false
-# List of servers which ViaFabric will force disabling transforming on client-side. It can be overwritten by setting per-server version.
-# This isn't always the address in multiplayer GUI. It will use the SRV record pointer when present. Check the game log for the address.
+# List of servers which ViaFabric will force disabling transforming on client-side. It can be overwritten by setting per-server version,
+#
+# This isn't always the address in multiplayer menu; It will use the SRV record pointer when present, Check the game log for the address.
 # Uses https://wiki.vg/Mojang_API#Blocked_Servers format (mc.example.com, *.example.com, 192.168.0.1, 192.168.*)
 client-side-force-disable: ["hypixel.net", "*.hypixel.net", "minemen.club", "*.minemen.club"]


### PR DESCRIPTION
* Updates the warning text to be a disclaimer instead and re-uses the same text as the one for enabling client-side mode,
* Corrects a typo for client-side-version value section,
* Seperates disclaimer and "list of servers" to new line.

This is similar to the previous PR #173 but focuses on the config file instead and just like the previous one, edits are welcomed.