### PR TITLE
Upstream GitHub Actions and correct typo in bug report issues.

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -7,7 +7,7 @@ body:
     attributes:
       value: |
         **Before reporting a bug, please see if using master/dev builds from https://ci.viaversion.com/ fixes your issue.**
-        Whenever you see fit, you can upload images or video to any of the textfields.
+        Whenever you see fit, you can upload images or videos to any of the text fields.
 
   - type: input
     attributes:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -8,13 +8,13 @@ on: [ pull_request, push ]
 
 jobs:
   build:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
-      - uses: actions/checkout@v2
-      - uses: actions/setup-java@v1
+      - uses: actions/checkout@v3
+      - uses: actions/setup-java@v3
         with:
           java-version: 17
-      - uses: actions/cache@v2
+      - uses: actions/cache@v3
         with:
           path: |
             ~/.gradle/caches
@@ -24,7 +24,7 @@ jobs:
             ${{ runner.os }}-gradle-
       - name: build
         run: ./gradlew build
-      - uses: actions/upload-artifact@v2
+      - uses: actions/upload-artifact@v3
         with:
           name: Artifacts
           path: build/libs/

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -8,10 +8,10 @@ on: [workflow_dispatch] # Manual trigger
 
 jobs:
   build:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
-      - uses: actions/checkout@v2
-      - uses: actions/setup-java@v1
+      - uses: actions/checkout@v3
+      - uses: actions/setup-java@v3
         with:
           java-version: 17
       - name: build and publish
@@ -19,7 +19,7 @@ jobs:
           CURSEFORGE_API_KEY: ${{ secrets.CREEPER_CF }}
           MODRINTH_TOKEN: ${{ secrets.MODRINTH_TOKEN }}
         run: ./gradlew curseforge modrinth
-      - uses: actions/upload-artifact@v2
+      - uses: actions/upload-artifact@v3
         with:
           name: Artifacts
           path: build/libs/


### PR DESCRIPTION
Title says it all - This will update the following:

Ubuntu from 20.04 LTS -> 22.04 LTS,
Checkout from v2 -> v3,
Setup-Java from v1 -> v3,
Cache from v2 -> v3,
Upload-Artifact from v2 -> v3.

This includes a slight typo fix when making bug report issues.