### PR TITLE
Ensure setup-java uses temurin instead of blank value.

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -13,7 +13,8 @@ jobs:
       - uses: actions/checkout@v3
       - uses: actions/setup-java@v3
         with:
-          java-version: 17
+         distribution: 'temurin'
+         java-version: 17
       - uses: actions/cache@v3
         with:
           path: |

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -13,7 +13,8 @@ jobs:
       - uses: actions/checkout@v3
       - uses: actions/setup-java@v3
         with:
-          java-version: 17
+         distribution: 'temurin'
+         java-version: 17
       - name: build and publish
         env:
           CURSEFORGE_API_KEY: ${{ secrets.CREEPER_CF }}


### PR DESCRIPTION
Fixes the "setup-java" context as v3 now requires the distribution context to be included.