### PR TITLE
Show protocol version and advertised version in server listing

### DIFF
--- a/src/main/resources/assets/viafabric/lang/en_us.json
+++ b/src/main/resources/assets/viafabric/lang/en_us.json
@@ -7,7 +7,7 @@
   "gui.viafabric_config.title": "ViaFabric Configurations",
   "gui.client_side.enable": "Enable client-side",
   "gui.client_side.disable": "Disable client-side",
-  "gui.ping_version.translated": "VIA: %s",
+  "gui.ping_version.translated": "VIA: %s (%s)",
   "gui.hide_via_button.enable": "Hide VIA button",
   "gui.hide_via_button.disable": "Show VIA button",
   "gui.via_button": "VIA"

--- a/viafabric-mc114/src/main/java/com/viaversion/fabric/mc114/mixin/gui/client/MixinMultiplayerServerListPingerListener.java
+++ b/viafabric-mc114/src/main/java/com/viaversion/fabric/mc114/mixin/gui/client/MixinMultiplayerServerListPingerListener.java
@@ -1,0 +1,34 @@
+package com.viaversion.fabric.mc114.mixin.gui.client;
+
+
+import com.viaversion.fabric.common.gui.ViaServerInfo;
+import com.viaversion.fabric.common.handler.FabricDecodeHandler;
+import com.viaversion.fabric.mc114.mixin.debug.client.MixinClientConnectionAccessor;
+import net.minecraft.client.network.ServerInfo;
+import net.minecraft.network.ClientConnection;
+import net.minecraft.network.listener.ClientQueryPacketListener;
+import net.minecraft.network.packet.s2c.query.QueryResponseS2CPacket;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.gen.Accessor;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
+
+@Mixin(targets = "net.minecraft.client.network.MultiplayerServerListPinger$1")
+public abstract class MixinMultiplayerServerListPingerListener implements ClientQueryPacketListener {
+    @Accessor
+    abstract ClientConnection getField_3774(); // Synthetic
+
+    @Accessor
+    abstract ServerInfo getField_3776(); // Synthetic
+
+    @Inject(method = "onResponse", at = @At(value = "HEAD"))
+    private void onResponseCaptureServerInfo(QueryResponseS2CPacket packet, CallbackInfo ci) {
+        FabricDecodeHandler decoder = ((MixinClientConnectionAccessor) this.getField_3774()).getChannel()
+                .pipeline().get(FabricDecodeHandler.class);
+        if (decoder != null) {
+            ((ViaServerInfo) getField_3776()).setViaTranslating(decoder.getInfo().isActive());
+            ((ViaServerInfo) getField_3776()).setViaServerVer(decoder.getInfo().getProtocolInfo().getServerProtocolVersion());
+        }
+    }
+}

--- a/viafabric-mc114/src/main/java/com/viaversion/fabric/mc114/mixin/gui/client/MixinServerEntry.java
+++ b/viafabric-mc114/src/main/java/com/viaversion/fabric/mc114/mixin/gui/client/MixinServerEntry.java
@@ -1,0 +1,43 @@
+package com.viaversion.fabric.mc114.mixin.gui.client;
+
+import com.viaversion.fabric.common.gui.ViaServerInfo;
+import com.viaversion.viaversion.api.protocol.version.ProtocolVersion;
+import net.minecraft.client.gui.DrawableHelper;
+import net.minecraft.client.gui.screen.multiplayer.MultiplayerScreen;
+import net.minecraft.client.gui.screen.multiplayer.MultiplayerServerListWidget;
+import net.minecraft.client.network.ServerInfo;
+import net.minecraft.client.texture.TextureManager;
+import net.minecraft.text.TranslatableText;
+import net.minecraft.util.Identifier;
+import org.spongepowered.asm.mixin.Final;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.Shadow;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Redirect;
+
+@Mixin(MultiplayerServerListWidget.ServerEntry.class)
+public class MixinServerEntry {
+    @Shadow
+    @Final
+    private ServerInfo server;
+
+    @Redirect(method = "render", at = @At(value = "INVOKE", ordinal = 0, target = "Lnet/minecraft/client/texture/TextureManager;bindTexture(Lnet/minecraft/util/Identifier;)V"))
+    private void redirectPingIcon(TextureManager textureManager, Identifier identifier) {
+        if (identifier.equals(DrawableHelper.GUI_ICONS_LOCATION) && ((ViaServerInfo) this.server).isViaTranslating()) {
+            textureManager.bindTexture(new Identifier("viafabric:textures/gui/icons.png"));
+            return;
+        }
+        textureManager.bindTexture(identifier);
+    }
+
+    @Redirect(method = "render", at = @At(value = "INVOKE", ordinal = 0, target = "Lnet/minecraft/client/gui/screen/multiplayer/MultiplayerScreen;setTooltip(Ljava/lang/String;)V"))
+    private void addServerVer(MultiplayerScreen multiplayerScreen, String text) {
+        ProtocolVersion proto = ProtocolVersion.getProtocol(((ViaServerInfo) this.server).getViaServerVer());
+        StringBuilder builder = new StringBuilder(text);
+        builder.append("\n");
+        builder.append((new TranslatableText("gui.ping_version.translated", proto.getName(), proto.getVersion())).asString());
+        builder.append("\n");
+        builder.append(this.server.version);
+        multiplayerScreen.setTooltip(builder.toString());
+    }
+}

--- a/viafabric-mc114/src/main/java/com/viaversion/fabric/mc114/mixin/gui/client/MixinServerInfo.java
+++ b/viafabric-mc114/src/main/java/com/viaversion/fabric/mc114/mixin/gui/client/MixinServerInfo.java
@@ -1,0 +1,30 @@
+package com.viaversion.fabric.mc114.mixin.gui.client;
+
+
+import com.viaversion.fabric.common.gui.ViaServerInfo;
+import net.minecraft.client.network.ServerInfo;
+import org.spongepowered.asm.mixin.Mixin;
+
+@Mixin(ServerInfo.class)
+public class MixinServerInfo implements ViaServerInfo {
+    private boolean viaTranslating;
+    private int viaServerVer;
+
+    public int getViaServerVer() {
+        return viaServerVer;
+    }
+
+    public void setViaServerVer(int viaServerVer) {
+        this.viaServerVer = viaServerVer;
+    }
+
+    @Override
+    public boolean isViaTranslating() {
+        return viaTranslating;
+    }
+
+    @Override
+    public void setViaTranslating(boolean via) {
+        this.viaTranslating = via;
+    }
+}

--- a/viafabric-mc114/src/main/resources/mixins.viafabric114.gui.json
+++ b/viafabric-mc114/src/main/resources/mixins.viafabric114.gui.json
@@ -3,9 +3,12 @@
   "compatibilityLevel": "JAVA_8",
   "package": "com.viaversion.fabric.mc114.mixin.gui",
   "mixins": [
+    "client.MixinMultiplayerServerListPingerListener"
   ],
   "client": [
-    "client.MixinMultiplayerScreen"
+    "client.MixinMultiplayerScreen",
+    "client.MixinServerEntry",
+    "client.MixinServerInfo"
   ],
   "injectors": {
     "defaultRequire": 0

--- a/viafabric-mc115/src/main/java/com/viaversion/fabric/mc115/mixin/gui/client/MixinMultiplayerServerListPingerListener.java
+++ b/viafabric-mc115/src/main/java/com/viaversion/fabric/mc115/mixin/gui/client/MixinMultiplayerServerListPingerListener.java
@@ -1,0 +1,34 @@
+package com.viaversion.fabric.mc115.mixin.gui.client;
+
+
+import com.viaversion.fabric.common.gui.ViaServerInfo;
+import com.viaversion.fabric.common.handler.FabricDecodeHandler;
+import com.viaversion.fabric.mc115.mixin.debug.client.MixinClientConnectionAccessor;
+import net.minecraft.client.network.ServerInfo;
+import net.minecraft.network.ClientConnection;
+import net.minecraft.network.listener.ClientQueryPacketListener;
+import net.minecraft.network.packet.s2c.query.QueryResponseS2CPacket;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.gen.Accessor;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
+
+@Mixin(targets = "net.minecraft.client.network.MultiplayerServerListPinger$1")
+public abstract class MixinMultiplayerServerListPingerListener implements ClientQueryPacketListener {
+    @Accessor
+    abstract ClientConnection getField_3774(); // Synthetic
+
+    @Accessor
+    abstract ServerInfo getField_3776(); // Synthetic
+
+    @Inject(method = "onResponse", at = @At(value = "HEAD"))
+    private void onResponseCaptureServerInfo(QueryResponseS2CPacket packet, CallbackInfo ci) {
+        FabricDecodeHandler decoder = ((MixinClientConnectionAccessor) this.getField_3774()).getChannel()
+                .pipeline().get(FabricDecodeHandler.class);
+        if (decoder != null) {
+            ((ViaServerInfo) getField_3776()).setViaTranslating(decoder.getInfo().isActive());
+            ((ViaServerInfo) getField_3776()).setViaServerVer(decoder.getInfo().getProtocolInfo().getServerProtocolVersion());
+        }
+    }
+}

--- a/viafabric-mc115/src/main/java/com/viaversion/fabric/mc115/mixin/gui/client/MixinServerEntry.java
+++ b/viafabric-mc115/src/main/java/com/viaversion/fabric/mc115/mixin/gui/client/MixinServerEntry.java
@@ -1,0 +1,43 @@
+package com.viaversion.fabric.mc115.mixin.gui.client;
+
+import com.viaversion.fabric.common.gui.ViaServerInfo;
+import com.viaversion.viaversion.api.protocol.version.ProtocolVersion;
+import net.minecraft.client.gui.DrawableHelper;
+import net.minecraft.client.gui.screen.multiplayer.MultiplayerScreen;
+import net.minecraft.client.gui.screen.multiplayer.MultiplayerServerListWidget;
+import net.minecraft.client.network.ServerInfo;
+import net.minecraft.client.texture.TextureManager;
+import net.minecraft.text.TranslatableText;
+import net.minecraft.util.Identifier;
+import org.spongepowered.asm.mixin.Final;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.Shadow;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Redirect;
+
+@Mixin(MultiplayerServerListWidget.ServerEntry.class)
+public class MixinServerEntry {
+    @Shadow
+    @Final
+    private ServerInfo server;
+
+    @Redirect(method = "render", at = @At(value = "INVOKE", ordinal = 0, target = "Lnet/minecraft/client/texture/TextureManager;bindTexture(Lnet/minecraft/util/Identifier;)V"))
+    private void redirectPingIcon(TextureManager textureManager, Identifier identifier) {
+        if (identifier.equals(DrawableHelper.GUI_ICONS_LOCATION) && ((ViaServerInfo) this.server).isViaTranslating()) {
+            textureManager.bindTexture(new Identifier("viafabric:textures/gui/icons.png"));
+            return;
+        }
+        textureManager.bindTexture(identifier);
+    }
+
+    @Redirect(method = "render", at = @At(value = "INVOKE", ordinal = 0, target = "Lnet/minecraft/client/gui/screen/multiplayer/MultiplayerScreen;setTooltip(Ljava/lang/String;)V"))
+    private void addServerVer(MultiplayerScreen multiplayerScreen, String text) {
+        ProtocolVersion proto = ProtocolVersion.getProtocol(((ViaServerInfo) this.server).getViaServerVer());
+        StringBuilder builder = new StringBuilder(text);
+        builder.append("\n");
+        builder.append((new TranslatableText("gui.ping_version.translated", proto.getName(), proto.getVersion())).asString());
+        builder.append("\n");
+        builder.append(this.server.version);
+        multiplayerScreen.setTooltip(builder.toString());
+    }
+}

--- a/viafabric-mc115/src/main/java/com/viaversion/fabric/mc115/mixin/gui/client/MixinServerInfo.java
+++ b/viafabric-mc115/src/main/java/com/viaversion/fabric/mc115/mixin/gui/client/MixinServerInfo.java
@@ -1,0 +1,30 @@
+package com.viaversion.fabric.mc115.mixin.gui.client;
+
+
+import com.viaversion.fabric.common.gui.ViaServerInfo;
+import net.minecraft.client.network.ServerInfo;
+import org.spongepowered.asm.mixin.Mixin;
+
+@Mixin(ServerInfo.class)
+public class MixinServerInfo implements ViaServerInfo {
+    private boolean viaTranslating;
+    private int viaServerVer;
+
+    public int getViaServerVer() {
+        return viaServerVer;
+    }
+
+    public void setViaServerVer(int viaServerVer) {
+        this.viaServerVer = viaServerVer;
+    }
+
+    @Override
+    public boolean isViaTranslating() {
+        return viaTranslating;
+    }
+
+    @Override
+    public void setViaTranslating(boolean via) {
+        this.viaTranslating = via;
+    }
+}

--- a/viafabric-mc115/src/main/resources/mixins.viafabric115.gui.json
+++ b/viafabric-mc115/src/main/resources/mixins.viafabric115.gui.json
@@ -3,9 +3,12 @@
   "compatibilityLevel": "JAVA_8",
   "package": "com.viaversion.fabric.mc115.mixin.gui",
   "mixins": [
+    "client.MixinMultiplayerServerListPingerListener"
   ],
   "client": [
-    "client.MixinMultiplayerScreen"
+    "client.MixinMultiplayerScreen",
+    "client.MixinServerEntry",
+    "client.MixinServerInfo"
   ],
   "injectors": {
     "defaultRequire": 0

--- a/viafabric-mc116/src/main/java/com/viaversion/fabric/mc116/mixin/gui/client/MixinMultiplayerServerListPingerListener.java
+++ b/viafabric-mc116/src/main/java/com/viaversion/fabric/mc116/mixin/gui/client/MixinMultiplayerServerListPingerListener.java
@@ -1,0 +1,34 @@
+package com.viaversion.fabric.mc116.mixin.gui.client;
+
+
+import com.viaversion.fabric.common.gui.ViaServerInfo;
+import com.viaversion.fabric.common.handler.FabricDecodeHandler;
+import com.viaversion.fabric.mc116.mixin.debug.client.MixinClientConnectionAccessor;
+import net.minecraft.client.network.ServerInfo;
+import net.minecraft.network.ClientConnection;
+import net.minecraft.network.listener.ClientQueryPacketListener;
+import net.minecraft.network.packet.s2c.query.QueryResponseS2CPacket;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.gen.Accessor;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
+
+@Mixin(targets = "net.minecraft.client.network.MultiplayerServerListPinger$1")
+public abstract class MixinMultiplayerServerListPingerListener implements ClientQueryPacketListener {
+    @Accessor
+    abstract ClientConnection getField_3774(); // Synthetic
+
+    @Accessor
+    abstract ServerInfo getField_3776(); // Synthetic
+
+    @Inject(method = "onResponse", at = @At(value = "HEAD"))
+    private void onResponseCaptureServerInfo(QueryResponseS2CPacket packet, CallbackInfo ci) {
+        FabricDecodeHandler decoder = ((MixinClientConnectionAccessor) this.getField_3774()).getChannel()
+                .pipeline().get(FabricDecodeHandler.class);
+        if (decoder != null) {
+            ((ViaServerInfo) getField_3776()).setViaTranslating(decoder.getInfo().isActive());
+            ((ViaServerInfo) getField_3776()).setViaServerVer(decoder.getInfo().getProtocolInfo().getServerProtocolVersion());
+        }
+    }
+}

--- a/viafabric-mc116/src/main/java/com/viaversion/fabric/mc116/mixin/gui/client/MixinServerEntry.java
+++ b/viafabric-mc116/src/main/java/com/viaversion/fabric/mc116/mixin/gui/client/MixinServerEntry.java
@@ -1,12 +1,12 @@
-package com.viaversion.fabric.mc118.mixin.gui.client;
+package com.viaversion.fabric.mc116.mixin.gui.client;
 
-import com.mojang.blaze3d.systems.RenderSystem;
 import com.viaversion.fabric.common.gui.ViaServerInfo;
 import com.viaversion.viaversion.api.protocol.version.ProtocolVersion;
 import net.minecraft.client.gui.DrawableHelper;
 import net.minecraft.client.gui.screen.multiplayer.MultiplayerScreen;
 import net.minecraft.client.gui.screen.multiplayer.MultiplayerServerListWidget;
 import net.minecraft.client.network.ServerInfo;
+import net.minecraft.client.texture.TextureManager;
 import net.minecraft.text.Text;
 import net.minecraft.text.TranslatableText;
 import net.minecraft.util.Identifier;
@@ -25,15 +25,13 @@ public class MixinServerEntry {
     @Final
     private ServerInfo server;
 
-    // todo fix this intermediary
-    @Redirect(method = "render", at = @At(value = "INVOKE", ordinal = 0,
-            target = "Lcom/mojang/blaze3d/systems/RenderSystem;setShaderTexture(ILnet/minecraft/class_2960;)V"))
-    private void redirectPingIcon(int i, Identifier identifier) {
+    @Redirect(method = "render", at = @At(value = "INVOKE", ordinal = 0, target = "Lnet/minecraft/client/texture/TextureManager;bindTexture(Lnet/minecraft/util/Identifier;)V"))
+    private void redirectPingIcon(TextureManager textureManager, Identifier identifier) {
         if (identifier.equals(DrawableHelper.GUI_ICONS_TEXTURE) && ((ViaServerInfo) this.server).isViaTranslating()) {
-            RenderSystem.setShaderTexture(i, new Identifier("viafabric:textures/gui/icons.png"));
+            textureManager.bindTexture(new Identifier("viafabric:textures/gui/icons.png"));
             return;
         }
-        RenderSystem.setShaderTexture(i, identifier);
+        textureManager.bindTexture(identifier);
     }
 
     @Redirect(method = "render", at = @At(value = "INVOKE", ordinal = 0, target = "Lnet/minecraft/client/gui/screen/multiplayer/MultiplayerScreen;setTooltip(Ljava/util/List;)V"))

--- a/viafabric-mc116/src/main/java/com/viaversion/fabric/mc116/mixin/gui/client/MixinServerInfo.java
+++ b/viafabric-mc116/src/main/java/com/viaversion/fabric/mc116/mixin/gui/client/MixinServerInfo.java
@@ -1,0 +1,30 @@
+package com.viaversion.fabric.mc116.mixin.gui.client;
+
+
+import com.viaversion.fabric.common.gui.ViaServerInfo;
+import net.minecraft.client.network.ServerInfo;
+import org.spongepowered.asm.mixin.Mixin;
+
+@Mixin(ServerInfo.class)
+public class MixinServerInfo implements ViaServerInfo {
+    private boolean viaTranslating;
+    private int viaServerVer;
+
+    public int getViaServerVer() {
+        return viaServerVer;
+    }
+
+    public void setViaServerVer(int viaServerVer) {
+        this.viaServerVer = viaServerVer;
+    }
+
+    @Override
+    public boolean isViaTranslating() {
+        return viaTranslating;
+    }
+
+    @Override
+    public void setViaTranslating(boolean via) {
+        this.viaTranslating = via;
+    }
+}

--- a/viafabric-mc116/src/main/resources/mixins.viafabric116.gui.json
+++ b/viafabric-mc116/src/main/resources/mixins.viafabric116.gui.json
@@ -3,9 +3,12 @@
   "compatibilityLevel": "JAVA_8",
   "package": "com.viaversion.fabric.mc116.mixin.gui",
   "mixins": [
+    "client.MixinMultiplayerServerListPingerListener"
   ],
   "client": [
-    "client.MixinMultiplayerScreen"
+    "client.MixinMultiplayerScreen",
+    "client.MixinServerEntry",
+    "client.MixinServerInfo"
   ],
   "injectors": {
     "defaultRequire": 0

--- a/viafabric-mc117/src/main/java/com/viaversion/fabric/mc117/mixin/gui/client/MixinServerEntry.java
+++ b/viafabric-mc117/src/main/java/com/viaversion/fabric/mc117/mixin/gui/client/MixinServerEntry.java
@@ -40,7 +40,8 @@ public class MixinServerEntry {
     private void addServerVer(MultiplayerScreen multiplayerScreen, List<Text> tooltipText) {
         ProtocolVersion proto = ProtocolVersion.getProtocol(((ViaServerInfo) this.server).getViaServerVer());
         List<Text> lines = new ArrayList<>(tooltipText);
-        lines.add(new TranslatableText("gui.ping_version.translated", proto.getName()));
+        lines.add(new TranslatableText("gui.ping_version.translated", proto.getName(), proto.getVersion()));
+        lines.add(this.server.version.copy());
         multiplayerScreen.setTooltip(lines);
     }
 }

--- a/viafabric-mc119/src/main/java/com/viaversion/fabric/mc119/mixin/gui/client/MixinServerEntry.java
+++ b/viafabric-mc119/src/main/java/com/viaversion/fabric/mc119/mixin/gui/client/MixinServerEntry.java
@@ -38,7 +38,8 @@ public class MixinServerEntry {
     private void addServerVer(MultiplayerScreen multiplayerScreen, List<Text> tooltipText) {
         ProtocolVersion proto = ProtocolVersion.getProtocol(((ViaServerInfo) this.server).getViaServerVer());
         List<Text> lines = new ArrayList<>(tooltipText);
-        lines.add(Text.translatable("gui.ping_version.translated", proto.getName()));
+        lines.add(Text.translatable("gui.ping_version.translated", proto.getName(), proto.getVersion()));
+        lines.add(this.server.version.copy());
         multiplayerScreen.setMultiplayerScreenTooltip(lines);
     }
 }

--- a/viafabric-mc120/src/main/java/com/viaversion/fabric/mc120/mixin/gui/client/MixinServerEntry.java
+++ b/viafabric-mc120/src/main/java/com/viaversion/fabric/mc120/mixin/gui/client/MixinServerEntry.java
@@ -38,7 +38,7 @@ public class MixinServerEntry {
     private void addServerVer(MultiplayerScreen multiplayerScreen, List<Text> tooltipText) {
         ProtocolVersion proto = ProtocolVersion.getProtocol(((ViaServerInfo) this.server).getViaServerVer());
         List<Text> lines = new ArrayList<>(tooltipText);
-        lines.add(Text.translatable("gui.ping_version.translated", proto.getName()));
+        lines.add(Text.translatable("gui.ping_version.translated", proto.getName(), proto.getVersion()));
         multiplayerScreen.setMultiplayerScreenTooltip(lines);
     }
 }


### PR DESCRIPTION
Backport showing protocol version to 1.16, 1.15 and 1.14

Shows additional info when hovering the connection bars

Some caveats: 
 - If protocol version is Unknown, the version will show as VIA: Unknown (Proto) (Proto)
 - If the protocol is not supported it shows the client's version rather than the server's version. This happens even without this PR, however I mention it because it's useful to see the actual server version/protocol version from within the client. Perhaps once this PR is merged I will open an issue or something

Before:
![image](https://user-images.githubusercontent.com/48024900/236700018-1104f2a8-e411-4c07-a088-cd5339fc83fd.png)
![image](https://user-images.githubusercontent.com/48024900/236700021-49bcac18-cfa4-4e64-b5b0-632a4156d378.png)


After:
![image](https://user-images.githubusercontent.com/48024900/236699959-1eed486f-8a54-4e62-8542-ebeba305261b.png)
![image](https://user-images.githubusercontent.com/48024900/236699965-ab709780-a9cc-4376-8e38-4827560cb9bf.png)