### PR TITLE
23w14a -> 23w18a.

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -3,11 +3,11 @@
 org.gradle.jvmargs=-Xms32M -Xmx4G -XX:+UseG1GC -XX:+UseStringDeduplication
 
 loader_version=0.14.19
-viaver_version=4.7.0-23w14a-SNAPSHOT
+viaver_version=4.7.0-23w18a-SNAPSHOT
 yaml_version=2.0
 
 publish_mc_versions=1.19.4, 1.18.2, 1.17.1, 1.16.5, 1.15.2, 1.14.4, 1.8.9
 # example: 1.19.1-rc2
-modrinth_mc_snapshot=23w14a
+modrinth_mc_snapshot=23w18a
 # example: 1.19-Snapshot
 curseforge_mc_snapshot=1.20-Snapshot


### PR DESCRIPTION
Swaps the `23w14a` build of viaversion with `23w18a` instead.