### PR TITLE
23w18a -> 1.20-pre1.

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -3,7 +3,7 @@
 org.gradle.jvmargs=-Xms32M -Xmx4G -XX:+UseG1GC -XX:+UseStringDeduplication
 
 loader_version=0.14.19
-viaver_version=4.7.0-23w18a-SNAPSHOT
+viaver_version=4.7.0-1.20-pre1-SNAPSHOT
 yaml_version=2.0
 
 publish_mc_versions=1.19.4, 1.18.2, 1.17.1, 1.16.5, 1.15.2, 1.14.4, 1.8.9

--- a/viafabric-mc120/build.gradle.kts
+++ b/viafabric-mc120/build.gradle.kts
@@ -1,8 +1,8 @@
 dependencies {
-    minecraft("com.mojang:minecraft:23w18a")
-    mappings("net.fabricmc:yarn:23w18a+build.4:v2")
+    minecraft("com.mojang:minecraft:1.20-pre1")
+    mappings("net.fabricmc:yarn:1.20-pre1+build.1:v2")
 
-    modImplementation("net.fabricmc.fabric-api:fabric-api:0.80.0+1.20")
+    modImplementation("net.fabricmc.fabric-api:fabric-api:0.80.2+1.20")
     modImplementation("com.terraformersmc:modmenu:7.0.0-beta.2")
 }
 


### PR DESCRIPTION
This PR replaces the 23w18a viaversion copy and yarn with 1.20-pre1 instead and seems to boot without issues on my end, however testing is still encouraged in case any fixes are required.