### PR TITLE
multiconnect -> ViaFabricPlus

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,22 +128,20 @@ registry synchronization (fabric-registry-sync mod).
 - Examples: ``minigame.example.com._v1_8.viafabric``, ``native.example.com._v-1.viafabric``
   , ``auto.example.com._v-2.viafabric``
 
-## multiconnect
+## ViaFabricPlus
 
-### Does it work with multiconnect at same time on client?:
+### Does it work with ViaFabric:
 
-- Yes, ViaFabric can be used with multiconnect. ViaFabric will send to its version auto detector the closest non-beta
-  supported version. (multiconnect beta-supported versions are currently < 1.11))
+- No, ViaFabric cannot be used with ViaFabricPlus.
 
-### Differences with multiconnect:
+### Differences with ViaFabricPlus:
 
-|                        | ViaVersion                        | multiconnect                                  |
-|------------------------|-----------------------------------|-----------------------------------------------|
-| Designed for           | servers                           | clients                                       |
-| Can be installed on    | multiple client/server versions   | latest client version                         |
-| Objectives             | simply implement ViaVersion       | version support with fixes to version changes |
-| How does it work?      | modifying packets at network code | modifying client code more deeply             |
-| Triggering anti-cheats | very likely                       | less likely                                   |
+|                                  | ViaFabric                                       | ViaFabricPlus                                                   |
+|----------------------------------|-------------------------------------------------|-----------------------------------------------------------------|
+| Can be installed on              | Multiple client/server versions with fabric     | Latest client-side version with fabric                          |
+| Objectives                       | Simply implement ViaVersion                     | Implements ViaVersion with client-side fixes to version changes |
+| How does it work?                | Modifying packets at network code               | Modifying client code more deeply                               |
+| Triggering anti-cheats           | Very likely                                     | Mostly not                                                      |
 
 ## Disclaimer
 

--- a/src/main/resources/fabric.mod.json
+++ b/src/main/resources/fabric.mod.json
@@ -16,6 +16,9 @@
     "minecraft": ["1.8.x", "1.14.4", "1.15.2", "~1.16.4", "1.17.1", "1.18.2", "~1.19.4", "1.20.x"],
     "viaversion": ">=4.0.0"
   },
+  "breaks": {
+    "viafabricplus": "*"
+  },
   "environment": "*",
   "authors": [
     {


### PR DESCRIPTION
This replaces multiconnect with ViaFabricPlus in the README difference list and marks it as an incompatible mod via the fabric.mod.json file.

Why this is done:

1. Multiconnect is archived and is no longer maintained,
2. ViaFabricPlus does not work with ViaFabric itself - Therefore is recommended we mark it into the breaks list,
3. ViaFabricPlus is basically "Multiconnect v2" according to @FlorianMichael.