### PR TITLE
Mark 1.8.x as minimium compatible version.

### DIFF
--- a/src/main/java/com/viaversion/fabric/common/platform/FabricInjector.java
+++ b/src/main/java/com/viaversion/fabric/common/platform/FabricInjector.java
@@ -45,7 +45,7 @@ public class FabricInjector implements ViaInjector {
         }
         // On client-side we can connect to any server version
         IntSortedSet versions = new IntLinkedOpenHashSet();
-        versions.add(ProtocolVersion.v1_7_1.getOriginalVersion());
+        versions.add(ProtocolVersion.v1_8.getOriginalVersion());
         versions.add(ProtocolVersion.getProtocols()
                 .stream()
                 .mapToInt(ProtocolVersion::getOriginalVersion)


### PR DESCRIPTION
Since ViaFabric marked 1.7.x and older as "won't translate" on client-side which is indicated by yellow text whereas 1.8.x is a supported protocol, this PR changes the minimium compatible version to 1.8.x instead to correct it.