### PR TITLE
Removed MovementTransmitterProvider use() call (updated ViaVersion to 4.7.1-SNAPSHOT)

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -3,7 +3,7 @@
 org.gradle.jvmargs=-Xms32M -Xmx4G -XX:+UseG1GC -XX:+UseStringDeduplication
 
 loader_version=0.14.21
-viaver_version=4.7.0
+viaver_version=4.7.1-SNAPSHOT
 yaml_version=2.0
 
 publish_mc_versions=1.20, 1.19.4, 1.18.2, 1.17.1, 1.16.5, 1.15.2, 1.14.4, 1.8.9

--- a/viafabric-mc114/src/main/java/com/viaversion/fabric/mc114/platform/VFLoader.java
+++ b/viafabric-mc114/src/main/java/com/viaversion/fabric/mc114/platform/VFLoader.java
@@ -8,15 +8,12 @@ import net.fabricmc.api.EnvType;
 import net.fabricmc.loader.api.FabricLoader;
 import com.viaversion.viaversion.api.Via;
 import com.viaversion.viaversion.api.platform.ViaPlatformLoader;
-import com.viaversion.viaversion.bungee.providers.BungeeMovementTransmitter;
 import com.viaversion.viaversion.api.protocol.version.VersionProvider;
 import com.viaversion.viaversion.protocols.protocol1_9to1_8.providers.HandItemProvider;
-import com.viaversion.viaversion.protocols.protocol1_9to1_8.providers.MovementTransmitterProvider;
 
 public class VFLoader implements ViaPlatformLoader {
     @Override
     public void load() {
-        Via.getManager().getProviders().use(MovementTransmitterProvider.class, new BungeeMovementTransmitter());
         Via.getManager().getProviders().use(VersionProvider.class, new FabricVersionProvider());
 
         if (Via.getPlatform().getConf().isItemCache()) {

--- a/viafabric-mc115/src/main/java/com/viaversion/fabric/mc115/platform/VFLoader.java
+++ b/viafabric-mc115/src/main/java/com/viaversion/fabric/mc115/platform/VFLoader.java
@@ -8,15 +8,12 @@ import net.fabricmc.api.EnvType;
 import net.fabricmc.loader.api.FabricLoader;
 import com.viaversion.viaversion.api.Via;
 import com.viaversion.viaversion.api.platform.ViaPlatformLoader;
-import com.viaversion.viaversion.bungee.providers.BungeeMovementTransmitter;
 import com.viaversion.viaversion.api.protocol.version.VersionProvider;
 import com.viaversion.viaversion.protocols.protocol1_9to1_8.providers.HandItemProvider;
-import com.viaversion.viaversion.protocols.protocol1_9to1_8.providers.MovementTransmitterProvider;
 
 public class VFLoader implements ViaPlatformLoader {
     @Override
     public void load() {
-        Via.getManager().getProviders().use(MovementTransmitterProvider.class, new BungeeMovementTransmitter());
         Via.getManager().getProviders().use(VersionProvider.class, new FabricVersionProvider());
 
         if (Via.getPlatform().getConf().isItemCache()) {

--- a/viafabric-mc116/src/main/java/com/viaversion/fabric/mc116/platform/VFLoader.java
+++ b/viafabric-mc116/src/main/java/com/viaversion/fabric/mc116/platform/VFLoader.java
@@ -10,15 +10,12 @@ import net.fabricmc.api.EnvType;
 import net.fabricmc.loader.api.FabricLoader;
 import com.viaversion.viaversion.api.Via;
 import com.viaversion.viaversion.api.platform.ViaPlatformLoader;
-import com.viaversion.viaversion.bungee.providers.BungeeMovementTransmitter;
 import com.viaversion.viaversion.api.protocol.version.VersionProvider;
 import com.viaversion.viaversion.protocols.protocol1_9to1_8.providers.HandItemProvider;
-import com.viaversion.viaversion.protocols.protocol1_9to1_8.providers.MovementTransmitterProvider;
 
 public class VFLoader implements ViaPlatformLoader {
     @Override
     public void load() {
-        Via.getManager().getProviders().use(MovementTransmitterProvider.class, new BungeeMovementTransmitter());
         Via.getManager().getProviders().use(VersionProvider.class, new FabricVersionProvider());
 
         if (Via.getPlatform().getConf().isItemCache()) {

--- a/viafabric-mc117/src/main/java/com/viaversion/fabric/mc117/platform/VFLoader.java
+++ b/viafabric-mc117/src/main/java/com/viaversion/fabric/mc117/platform/VFLoader.java
@@ -10,15 +10,12 @@ import net.fabricmc.api.EnvType;
 import net.fabricmc.loader.api.FabricLoader;
 import com.viaversion.viaversion.api.Via;
 import com.viaversion.viaversion.api.platform.ViaPlatformLoader;
-import com.viaversion.viaversion.bungee.providers.BungeeMovementTransmitter;
 import com.viaversion.viaversion.api.protocol.version.VersionProvider;
 import com.viaversion.viaversion.protocols.protocol1_9to1_8.providers.HandItemProvider;
-import com.viaversion.viaversion.protocols.protocol1_9to1_8.providers.MovementTransmitterProvider;
 
 public class VFLoader implements ViaPlatformLoader {
     @Override
     public void load() {
-        Via.getManager().getProviders().use(MovementTransmitterProvider.class, new BungeeMovementTransmitter());
         Via.getManager().getProviders().use(VersionProvider.class, new FabricVersionProvider());
 
         if (Via.getPlatform().getConf().isItemCache()) {

--- a/viafabric-mc118/src/main/java/com/viaversion/fabric/mc118/platform/VFLoader.java
+++ b/viafabric-mc118/src/main/java/com/viaversion/fabric/mc118/platform/VFLoader.java
@@ -10,15 +10,12 @@ import net.fabricmc.api.EnvType;
 import net.fabricmc.loader.api.FabricLoader;
 import com.viaversion.viaversion.api.Via;
 import com.viaversion.viaversion.api.platform.ViaPlatformLoader;
-import com.viaversion.viaversion.bungee.providers.BungeeMovementTransmitter;
 import com.viaversion.viaversion.api.protocol.version.VersionProvider;
 import com.viaversion.viaversion.protocols.protocol1_9to1_8.providers.HandItemProvider;
-import com.viaversion.viaversion.protocols.protocol1_9to1_8.providers.MovementTransmitterProvider;
 
 public class VFLoader implements ViaPlatformLoader {
     @Override
     public void load() {
-        Via.getManager().getProviders().use(MovementTransmitterProvider.class, new BungeeMovementTransmitter());
         Via.getManager().getProviders().use(VersionProvider.class, new FabricVersionProvider());
 
         if (Via.getPlatform().getConf().isItemCache()) {

--- a/viafabric-mc119/src/main/java/com/viaversion/fabric/mc119/platform/VFLoader.java
+++ b/viafabric-mc119/src/main/java/com/viaversion/fabric/mc119/platform/VFLoader.java
@@ -10,15 +10,12 @@ import net.fabricmc.api.EnvType;
 import net.fabricmc.loader.api.FabricLoader;
 import com.viaversion.viaversion.api.Via;
 import com.viaversion.viaversion.api.platform.ViaPlatformLoader;
-import com.viaversion.viaversion.bungee.providers.BungeeMovementTransmitter;
 import com.viaversion.viaversion.api.protocol.version.VersionProvider;
 import com.viaversion.viaversion.protocols.protocol1_9to1_8.providers.HandItemProvider;
-import com.viaversion.viaversion.protocols.protocol1_9to1_8.providers.MovementTransmitterProvider;
 
 public class VFLoader implements ViaPlatformLoader {
     @Override
     public void load() {
-        Via.getManager().getProviders().use(MovementTransmitterProvider.class, new BungeeMovementTransmitter());
         Via.getManager().getProviders().use(VersionProvider.class, new FabricVersionProvider());
 
         if (Via.getPlatform().getConf().isItemCache()) {

--- a/viafabric-mc120/src/main/java/com/viaversion/fabric/mc120/platform/VFLoader.java
+++ b/viafabric-mc120/src/main/java/com/viaversion/fabric/mc120/platform/VFLoader.java
@@ -10,15 +10,12 @@ import net.fabricmc.api.EnvType;
 import net.fabricmc.loader.api.FabricLoader;
 import com.viaversion.viaversion.api.Via;
 import com.viaversion.viaversion.api.platform.ViaPlatformLoader;
-import com.viaversion.viaversion.bungee.providers.BungeeMovementTransmitter;
 import com.viaversion.viaversion.api.protocol.version.VersionProvider;
 import com.viaversion.viaversion.protocols.protocol1_9to1_8.providers.HandItemProvider;
-import com.viaversion.viaversion.protocols.protocol1_9to1_8.providers.MovementTransmitterProvider;
 
 public class VFLoader implements ViaPlatformLoader {
     @Override
     public void load() {
-        Via.getManager().getProviders().use(MovementTransmitterProvider.class, new BungeeMovementTransmitter());
         Via.getManager().getProviders().use(VersionProvider.class, new FabricVersionProvider());
 
         if (Via.getPlatform().getConf().isItemCache()) {

--- a/viafabric-mc18/src/main/java/com/viaversion/fabric/mc18/platform/VFLoader.java
+++ b/viafabric-mc18/src/main/java/com/viaversion/fabric/mc18/platform/VFLoader.java
@@ -6,15 +6,12 @@ import net.fabricmc.api.EnvType;
 import net.fabricmc.loader.api.FabricLoader;
 import com.viaversion.viaversion.api.Via;
 import com.viaversion.viaversion.api.platform.ViaPlatformLoader;
-import com.viaversion.viaversion.bungee.providers.BungeeMovementTransmitter;
 import com.viaversion.viaversion.api.protocol.version.VersionProvider;
 import com.viaversion.viaversion.protocols.protocol1_9to1_8.providers.HandItemProvider;
-import com.viaversion.viaversion.protocols.protocol1_9to1_8.providers.MovementTransmitterProvider;
 
 public class VFLoader implements ViaPlatformLoader {
     @Override
     public void load() {
-        Via.getManager().getProviders().use(MovementTransmitterProvider.class, new BungeeMovementTransmitter());
         Via.getManager().getProviders().use(VersionProvider.class, new FabricVersionProvider());
 
         if (Via.getPlatform().getConf().isItemCache()) {


### PR DESCRIPTION
This PR implements the API Changes from https://github.com/ViaVersion/ViaVersion/commit/a817746edc971cc3d552e2ddb0591392f7241215