### PR TITLE
Update ViaVersion, CI and MC dependencies.

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,8 +1,3 @@
-# Automatically build the project and run any configured tests for every push
-# and submitted pull request. This can help catch issues that only occur on
-# certain platforms or Java versions, and provides a first line of defence
-# against bad commits.
-
 name: build
 on: [ pull_request, push ]
 
@@ -10,13 +5,17 @@ jobs:
   build:
     runs-on: ubuntu-22.04
     steps:
-      - uses: actions/checkout@v3
-      - uses: gradle/wrapper-validation-action@v1
-      - uses: actions/setup-java@v3
+      - name: Checkout Repository
+        uses: actions/checkout@v3
+      - name: Validate Gradle Wrapper
+        uses: gradle/wrapper-validation-action@v1
+      - name: Set up JDK 17
+        uses: actions/setup-java@v3
         with:
          distribution: 'temurin'
          java-version: 17
-      - uses: actions/cache@v3
+      - name: Cache Dependencies
+        uses: actions/cache@v3
         with:
           path: |
             ~/.gradle/caches
@@ -24,9 +23,10 @@ jobs:
           key: ${{ runner.os }}-gradle-${{ hashFiles('**/*.gradle*', '**/gradle-wrapper.properties') }}
           restore-keys: |
             ${{ runner.os }}-gradle-
-      - name: build
+      - name: Build with Gradle
         run: ./gradlew build
-      - uses: actions/upload-artifact@v3
+      - name: Upload Artifacts
+        uses: actions/upload-artifact@v3
         with:
           name: Artifacts
           path: build/libs/

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,8 +1,3 @@
-# Automatically build the project and run any configured tests for every push
-# and submitted pull request. This can help catch issues that only occur on
-# certain platforms or Java versions, and provides a first line of defence
-# against bad commits.
-
 name: publish
 on: [workflow_dispatch] # Manual trigger
 
@@ -10,18 +5,22 @@ jobs:
   build:
     runs-on: ubuntu-22.04
     steps:
-      - uses: actions/checkout@v3
-      - uses: gradle/wrapper-validation-action@v1
-      - uses: actions/setup-java@v3
+      - name: Checkout Repository
+        uses: actions/checkout@v3
+      - name: Validate Gradle Wrapper
+        uses: gradle/wrapper-validation-action@v1
+      - name: Set up JDK 17
+        uses: actions/setup-java@v3
         with:
          distribution: 'temurin'
          java-version: 17
-      - name: build and publish
+      - name: Build and Publish
         env:
           CURSEFORGE_API_KEY: ${{ secrets.CREEPER_CF }}
           MODRINTH_TOKEN: ${{ secrets.MODRINTH_TOKEN }}
         run: ./gradlew curseforge modrinth
-      - uses: actions/upload-artifact@v3
+      - name: Upload Artifacts
+        uses: actions/upload-artifact@v3
         with:
           name: Artifacts
           path: build/libs/

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -2,7 +2,8 @@ name: publish
 on: [workflow_dispatch] # Manual trigger
 
 jobs:
-  build:
+  publish:
+    if: github.repository_owner == 'ViaVersion'
     runs-on: ubuntu-22.04
     steps:
       - name: Checkout Repository

--- a/build.gradle
+++ b/build.gradle
@@ -11,9 +11,9 @@ plugins {
     id "maven-publish"
     id "org.ajoberstar.grgit" version "5.2.0"
     id "com.matthewprenger.cursegradle" version "1.4.0"
-    id "com.modrinth.minotaur" version "2.7.5"
+    id "com.modrinth.minotaur" version "2.8.1"
     id "fabric-loom" version "1.2-SNAPSHOT" apply false
-    id "com.github.ben-manes.versions" version "0.46.0"
+    id "com.github.ben-manes.versions" version "0.47.0"
 }
 
 def ENV = System.getenv()

--- a/gradle.properties
+++ b/gradle.properties
@@ -3,7 +3,7 @@
 org.gradle.jvmargs=-Xms32M -Xmx4G -XX:+UseG1GC -XX:+UseStringDeduplication
 
 loader_version=0.14.21
-viaver_version=4.7.0
+viaver_version=4.7.1-SNAPSHOT
 yaml_version=2.0
 
 publish_mc_versions=1.20, 1.19.4, 1.18.2, 1.17.1, 1.16.5, 1.15.2, 1.14.4, 1.8.9

--- a/viafabric-mc114/build.gradle.kts
+++ b/viafabric-mc114/build.gradle.kts
@@ -3,6 +3,6 @@ dependencies {
     mappings("net.fabricmc:yarn:1.14.4+build.18:v2")
 
     modImplementation("net.fabricmc.fabric-api:fabric-api:0.28.5+1.14")
-    modImplementation("io.github.prospector:modmenu:1.7.17")
+    modImplementation("io.github.prospector:modmenu:1.7.17+build.1")
     modImplementation("com.github.TinfoilMC:ClientCommands:1.1.0")
 }

--- a/viafabric-mc114/build.gradle.kts
+++ b/viafabric-mc114/build.gradle.kts
@@ -3,6 +3,6 @@ dependencies {
     mappings("net.fabricmc:yarn:1.14.4+build.18:v2")
 
     modImplementation("net.fabricmc.fabric-api:fabric-api:0.28.5+1.14")
-    modImplementation("io.github.prospector:modmenu:1.7.16.1.14.4+build.128")
+    modImplementation("io.github.prospector:modmenu:1.7.17")
     modImplementation("com.github.TinfoilMC:ClientCommands:1.1.0")
 }

--- a/viafabric-mc115/build.gradle.kts
+++ b/viafabric-mc115/build.gradle.kts
@@ -3,6 +3,6 @@ dependencies {
     mappings("net.fabricmc:yarn:1.15.2+build.17:v2")
 
     modImplementation("net.fabricmc.fabric-api:fabric-api:0.28.5+1.15")
-    modImplementation("io.github.prospector:modmenu:1.10.7")
+    modImplementation("io.github.prospector:modmenu:1.10.4+build.1")
     modImplementation("com.github.TinfoilMC:ClientCommands:1.1.0")
 }

--- a/viafabric-mc115/build.gradle.kts
+++ b/viafabric-mc115/build.gradle.kts
@@ -3,6 +3,6 @@ dependencies {
     mappings("net.fabricmc:yarn:1.15.2+build.17:v2")
 
     modImplementation("net.fabricmc.fabric-api:fabric-api:0.28.5+1.15")
-    modImplementation("io.github.prospector:modmenu:1.10.2+build.32")
+    modImplementation("io.github.prospector:modmenu:1.10.7")
     modImplementation("com.github.TinfoilMC:ClientCommands:1.1.0")
 }

--- a/viafabric-mc116/build.gradle.kts
+++ b/viafabric-mc116/build.gradle.kts
@@ -3,5 +3,5 @@ dependencies {
     mappings("net.fabricmc:yarn:1.16.5+build.10:v2")
 
     modImplementation("net.fabricmc.fabric-api:fabric-api:0.42.0+1.16")
-    modImplementation("com.terraformersmc:modmenu:1.16.9")
+    modImplementation("com.terraformersmc:modmenu:1.16.23")
 }

--- a/viafabric-mc117/build.gradle.kts
+++ b/viafabric-mc117/build.gradle.kts
@@ -3,5 +3,5 @@ dependencies {
     mappings("net.fabricmc:yarn:1.17.1+build.65:v2")
 
     modImplementation("net.fabricmc.fabric-api:fabric-api:0.46.1+1.17")
-    modImplementation("com.terraformersmc:modmenu:2.0.2")
+    modImplementation("com.terraformersmc:modmenu:2.0.17")
 }

--- a/viafabric-mc118/build.gradle.kts
+++ b/viafabric-mc118/build.gradle.kts
@@ -1,6 +1,6 @@
 dependencies {
     minecraft("com.mojang:minecraft:1.18.2")
-    mappings("net.fabricmc:yarn:1.18.2+build.3:v2")
+    mappings("net.fabricmc:yarn:1.18.2+build.4:v2")
 
     modImplementation("net.fabricmc.fabric-api:fabric-api:0.76.0+1.18.2")
     modImplementation("com.terraformersmc:modmenu:3.2.5")

--- a/viafabric-mc118/build.gradle.kts
+++ b/viafabric-mc118/build.gradle.kts
@@ -2,6 +2,6 @@ dependencies {
     minecraft("com.mojang:minecraft:1.18.2")
     mappings("net.fabricmc:yarn:1.18.2+build.3:v2")
 
-    modImplementation("net.fabricmc.fabric-api:fabric-api:0.55.1+1.18.2")
-    modImplementation("com.terraformersmc:modmenu:3.0.0")
+    modImplementation("net.fabricmc.fabric-api:fabric-api:0.76.0+1.18.2")
+    modImplementation("com.terraformersmc:modmenu:3.2.5")
 }

--- a/viafabric-mc119/build.gradle.kts
+++ b/viafabric-mc119/build.gradle.kts
@@ -1,9 +1,9 @@
 dependencies {
-    minecraft("com.mojang:minecraft:1.19.4-rc2")
-    mappings("net.fabricmc:yarn:1.19.4-rc2+build.1:v2")
+    minecraft("com.mojang:minecraft:1.19.4")
+    mappings("net.fabricmc:yarn:1.19.4+build.1:v2")
 
-    modImplementation("net.fabricmc.fabric-api:fabric-api:0.75.3+1.19.4")
-    modImplementation("com.terraformersmc:modmenu:5.0.0-alpha.4")
+    modImplementation("net.fabricmc.fabric-api:fabric-api:0.83.0+1.19.4")
+    modImplementation("com.terraformersmc:modmenu:6.2.3")
 }
 
 tasks.compileJava {

--- a/viafabric-mc119/build.gradle.kts
+++ b/viafabric-mc119/build.gradle.kts
@@ -1,6 +1,6 @@
 dependencies {
     minecraft("com.mojang:minecraft:1.19.4")
-    mappings("net.fabricmc:yarn:1.19.4+build.1:v2")
+    mappings("net.fabricmc:yarn:1.19.4+build.2:v2")
 
     modImplementation("net.fabricmc.fabric-api:fabric-api:0.83.0+1.19.4")
     modImplementation("com.terraformersmc:modmenu:6.2.3")

--- a/viafabric-mc120/build.gradle.kts
+++ b/viafabric-mc120/build.gradle.kts
@@ -1,9 +1,9 @@
 dependencies {
-    minecraft("com.mojang:minecraft:1.20")
-    mappings("net.fabricmc:yarn:1.20+build.1:v2")
+    minecraft("com.mojang:minecraft:1.20.1")
+    mappings("net.fabricmc:yarn:1.20.1+build.1:v2")
 
-    modImplementation("net.fabricmc.fabric-api:fabric-api:0.83.0+1.20")
-    modImplementation("com.terraformersmc:modmenu:7.0.0")
+    modImplementation("net.fabricmc.fabric-api:fabric-api:0.83.1+1.20.1")
+    modImplementation("com.terraformersmc:modmenu:7.1.0")
 }
 
 tasks.compileJava {

--- a/viafabric-mc120/build.gradle.kts
+++ b/viafabric-mc120/build.gradle.kts
@@ -1,6 +1,6 @@
 dependencies {
     minecraft("com.mojang:minecraft:1.20.1")
-    mappings("net.fabricmc:yarn:1.20.1+build.1:v2")
+    mappings("net.fabricmc:yarn:1.20.1+build.2:v2")
 
     modImplementation("net.fabricmc.fabric-api:fabric-api:0.83.1+1.20.1")
     modImplementation("com.terraformersmc:modmenu:7.1.0")


### PR DESCRIPTION
Another "dependabot but human" moment but let's go:

Friendly names in CI however this one has the publishing script set to only run in the ViaVersion repository for safety reasons and now corrects the main job in `publish.yml` file to it's actual name instead of build,
Then ViaVersion will be updated to 4.7.1-SNAPSHOT to resolve issues such as 1.20.1 not being recognized in list command and other bug fixes,

Other dependencies that changed:

Minotaur: 2.7.5 -> 2.8.1,
ben-manes' versions software: 0.46.0 -> 0.47.0,
Mod Menu, Yarn and Fabric API are all updated to their latest versions respectively.