### PR TITLE
Update versioning table for client-side, Add required note.

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@
 
 Allows the connection to/from different Minecraft versions on your Minecraft client/server (LAN worlds too)
 
-This mod can be installed on 1.8.9, 1.14.4, 1.15.2, 1.16.5, 1.17.1, 1.18.2, 1.19.4, 1.20 with Fabric Loader.
+This mod can be installed on 1.8.9, 1.14.4, 1.15.2, 1.16.5, 1.17.1, 1.18.2, 1.19.4, 1.20.1 with Fabric Loader.
 
 ## Dependencies
 
@@ -47,19 +47,21 @@ registry synchronization (fabric-registry-sync mod).
 
 - Client-side:
 
-|               | 1.8.x | 1.9.x | 1.10-1.14.4 | 1.15.x | 1.16.x | 1.17.x | 1.18.x | 1.19.x | 1.20.x |
+|               | 1.8.9 | 1.9.x | 1.10-1.14.4 | 1.15.x | 1.16.x | 1.17.x | 1.18.x | 1.19.x | 1.20.x |
 |---------------|-------|-------|-------------|--------|--------|--------|--------|--------|--------|
 | 1.8.9 client  | ✓     | ⏪     | ⏪           | ⏪      | ⏪      | ⏪      | ⏪      | ⏪ | ⏪ |
-| 1.14.x client | ✓     | ✓     | ✓           | ⟲      | ⟲      | ⟲      | ⟲      | ⟲ | ⟲ |
-| 1.15.x client | ✓     | ✓     | ✓           | ✓      | ⟲      | ⟲      | ⟲      | ⟲ | ⟲ |
-| 1.16.x client | ✓     | ✓     | ✓           | ✓      | ✓      | ⟲      | ⟲      | ⟲ | ⟲ |
-| 1.17.x client | ✓     | ✓     | ✓           | ✓      | ✓      | ✓      | ⟲      | ⟲ | ⟲ |
-| 1.18.x client | ✓     | ✓     | ✓           | ✓      | ✓      | ✓      | ✓      | ⟲ | ⟲ |
-| 1.19.x client | ✓     | ✓     | ✓           | ✓      | ✓      | ✓      | ✓      | ✓ | ⟲ |
-| 1.20.x client | ✓     | ✓     | ✓           | ✓      | ✓      | ✓      | ✓      | ✓ | ✓ |
+| 1.14.4 client | ✓     | ✓     | ✓           | ⟲      | ⟲      | ⟲      | ⟲      | ⟲ | ⟲ |
+| 1.15.2 client | ✓     | ✓     | ✓           | ✓      | ⟲      | ⟲      | ⟲      | ⟲ | ⟲ |
+| 1.16.5 client | ✓     | ✓     | ✓           | ✓      | ✓      | ⟲      | ⟲      | ⟲ | ⟲ |
+| 1.17.1 client | ✓     | ✓     | ✓           | ✓      | ✓      | ✓      | ⟲      | ⟲ | ⟲ |
+| 1.18.2 client | ✓     | ✓     | ✓           | ✓      | ✓      | ✓      | ✓      | ⟲ | ⟲ |
+| 1.19.4 client | ✓     | ✓     | ✓           | ✓      | ✓      | ✓      | ✓      | ✓ | ⟲ |
+| 1.20.1 client | ✓     | ✓     | ✓           | ✓      | ✓      | ✓      | ✓      | ✓ | ✓ |
 
 ✓ = [ViaVersion](https://viaversion.com) ⟲ = [ViaBackwards](https://viaversion.com/backwards) ⏪
 = [ViaRewind](https://viaversion.com/rewind)
+
+*Note: 1.7.x is not supported in ViaFabric - 1.9.x, 1.10.x, 1.11.x, and 1.13.x may cause problems when visiting such servers in client-side.*
 
 ### Can ViaVersion, ViaBackwards and ViaRewind support snapshots?:
 

--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ registry synchronization (fabric-registry-sync mod).
 ✓ = [ViaVersion](https://viaversion.com) ⟲ = [ViaBackwards](https://viaversion.com/backwards) ⏪
 = [ViaRewind](https://viaversion.com/rewind)
 
-*Note: 1.7.x is not supported in ViaFabric - 1.9.x, 1.10.x, 1.11.x, and 1.13.x may cause problems when visiting such servers in client-side.*
+*Note: 1.7.x is not supported in ViaFabric - 1.9.x, 1.10.x, 1.11.x, and 1.13.x may cause problems when visiting such servers in client-side mode.*
 
 ### Can ViaVersion, ViaBackwards and ViaRewind support snapshots?:
 


### PR DESCRIPTION
1. The table will be updated to ensure only latest minor versions of Minecraft are supported throughout ViaFabric,
2. 1.7.x, 1.9.x - 1.11.x and 1.13.x are likely to cause problems whilst using client-side mode on such servers.