### PR TITLE
Prepare for ViaVersion 4.8.1, Update 1.20.2 dependencies.

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -2,7 +2,7 @@
 org.gradle.jvmargs=-Xms32M -Xmx4G -XX:+UseG1GC -XX:+UseStringDeduplication
 
 loader_version=0.14.22
-viaver_version=4.8.0
+viaver_version=4.8.1
 yaml_version=2.2
 
 publish_mc_versions=1.20.2, 1.19.4, 1.18.2, 1.17.1, 1.16.5, 1.15.2, 1.14.4, 1.8.9

--- a/src/main/resources/fabric.mod.json
+++ b/src/main/resources/fabric.mod.json
@@ -14,7 +14,7 @@
   "depends": {
     "fabricloader": ">=0.14.0",
     "minecraft": ["1.8.9", "1.14.4", "1.15.2", "1.16.5", "1.17.1", "1.18.2", "1.19.4", "1.20.2"],
-    "viaversion": ">=4.8.0"
+    "viaversion": ">=4.8.1"
   },
   "breaks": {
     "viafabricplus": "*"

--- a/viafabric-mc120/build.gradle.kts
+++ b/viafabric-mc120/build.gradle.kts
@@ -1,9 +1,9 @@
 dependencies {
     minecraft("com.mojang:minecraft:1.20.2")
-    mappings("net.fabricmc:yarn:1.20.2+build.1:v2")
+    mappings("net.fabricmc:yarn:1.20.2+build.2:v2")
 
-    modImplementation("net.fabricmc.fabric-api:fabric-api:0.89.0+1.20.2")
-    modImplementation("com.terraformersmc:modmenu:8.0.0-beta.2")
+    modImplementation("net.fabricmc.fabric-api:fabric-api:0.89.3+1.20.2")
+    modImplementation("com.terraformersmc:modmenu:8.0.0")
 }
 
 tasks.compileJava {


### PR DESCRIPTION
1. Updates the 1.20.2 dependencies so that yarn, mod menu and fabric api are on their latest versions,
2. Updates ViaVersion from 4.8.0 -> 4.8.1 to fix core-related bugs.

**Current known issues:**

1. High contrast is not supported which causes VIA icon to fallback to the default texture,
2. Programmer art + Blue Ping support are not properly supported yet in 1.20.2 as neither of them are sprites.