### PR TITLE
Update ViaVersion to 4.9.2

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -2,7 +2,7 @@
 org.gradle.jvmargs=-Xms32M -Xmx4G -XX:+UseG1GC -XX:+UseStringDeduplication
 
 loader_version=0.14.25
-viaver_version=4.9.1
+viaver_version=4.9.2
 yaml_version=2.2
 
 publish_mc_versions=1.20.3, 1.19.4, 1.18.2, 1.17.1, 1.16.5, 1.15.2, 1.14.4, 1.8.9


### PR DESCRIPTION
Updates ViaVersion to 4.9.2 which contains hotfixes such as map data not being read properly.