### PR TITLE
Undo ViaVersion dependency but update loader to 0.15.3

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,8 +1,8 @@
 # suppress inspection "UnusedProperty" for whole file
 org.gradle.jvmargs=-Xms32M -Xmx4G -XX:+UseG1GC -XX:+UseStringDeduplication
 
-loader_version=0.14.25
-viaver_version=4.10.0-23w51b-SNAPSHOT
+loader_version=0.15.3
+viaver_version=4.9.3-SNAPSHOT
 yaml_version=2.2
 
 publish_mc_versions=1.20.4, 1.19.4, 1.18.2, 1.17.1, 1.16.5, 1.15.2, 1.14.4, 1.8.9


### PR DESCRIPTION
1. Undos the viaversion dependency back to 4.9.3-SNAPSHOT as the dev version *(4.10.0)* has unfortunately managed to cause unexpected problems when connecting to specific servers.
2. Updates fabric loader to 0.15.3 to allow 1.20.5 snapshots to be tested for dev branch in case that is being worked on.