### PR TITLE
Revert fabric loom to 1.4

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -12,7 +12,7 @@ plugins {
     id "org.ajoberstar.grgit" version "5.2.1"
     id "com.matthewprenger.cursegradle" version "1.4.0"
     id "com.modrinth.minotaur" version "2.8.7"
-    id "fabric-loom" version "1.5-SNAPSHOT" apply false
+    id "fabric-loom" version "1.4-SNAPSHOT" apply false
     id "com.github.ben-manes.versions" version "0.50.0"
 }
 

--- a/viafabric-mc120/build.gradle.kts
+++ b/viafabric-mc120/build.gradle.kts
@@ -2,7 +2,7 @@ dependencies {
     minecraft("com.mojang:minecraft:1.20.4")
     mappings("net.fabricmc:yarn:1.20.4+build.3:v2")
 
-    modImplementation("net.fabricmc.fabric-api:fabric-api:0.95.0+1.20.4")
+    modImplementation("net.fabricmc.fabric-api:fabric-api:0.93.1+1.20.4")
     modImplementation("com.terraformersmc:modmenu:9.0.0")
 }
 


### PR DESCRIPTION
Since fabric loom essentially screws up viafabric's buildscript, it will be reverted for now until ofc a better solution is discovered. *(which is karma)*