### PR TITLE
Update wrapper-validation-action to v2

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -8,7 +8,7 @@ jobs:
       - name: Checkout Repository
         uses: actions/checkout@v4
       - name: Validate Gradle Wrapper
-        uses: gradle/wrapper-validation-action@v1
+        uses: gradle/wrapper-validation-action@v2
       - name: Set up JDK 17
         uses: actions/setup-java@v4
         with:

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -9,7 +9,7 @@ jobs:
       - name: Checkout Repository
         uses: actions/checkout@v4
       - name: Validate Gradle Wrapper
-        uses: gradle/wrapper-validation-action@v1
+        uses: gradle/wrapper-validation-action@v2
       - name: Set up JDK 17
         uses: actions/setup-java@v4
         with:


### PR DESCRIPTION
Resolves the node.js deprecation warning from the previous version of this dependency - origin conversation took place [here](https://github.com/gradle/wrapper-validation-action/pull/166),

Can be synced to other repos if needed.