### PR TITLE
Final dependency updates, ViaFabric 0.4.13

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -13,14 +13,14 @@ plugins {
     id "com.matthewprenger.cursegradle" version "1.4.0"
     id "com.modrinth.minotaur" version "2.8.7"
     id "fabric-loom" version "1.5-SNAPSHOT" apply false
-    id "com.github.ben-manes.versions" version "0.50.0"
+    id "com.github.ben-manes.versions" version "0.51.0"
 }
 
 def ENV = System.getenv()
 
 group = "com.viaversion.fabric"
 description = "Client-side and server-side ViaVersion implementation for Fabric"
-version = "0.4.12+" + ENV.GITHUB_RUN_NUMBER + "-" + getBranch()
+version = "0.4.13+" + ENV.GITHUB_RUN_NUMBER + "-" + getBranch()
 logger.lifecycle("Building ViaFabric: $version")
 
 def getBranch() {
@@ -166,7 +166,7 @@ processResources {
 List<String> mcReleases = Arrays.stream(rootProject.publish_mc_versions.toString().split(","))
         .map({ it -> it.trim() })
         .collect(Collectors.toList())
-List<String> javaVersions = IntStream.rangeClosed(8, 18)
+List<String> javaVersions = IntStream.rangeClosed(8, 17)
         .mapToObj { n -> (String) "Java $n" }
         .collect(Collectors.toList())
 String changelogMsg = "A changelog can be found at https://github.com/ViaVersion/ViaFabric/commits"

--- a/viafabric-mc18/build.gradle.kts
+++ b/viafabric-mc18/build.gradle.kts
@@ -1,6 +1,6 @@
 dependencies {
     minecraft("com.mojang:minecraft:1.8.9")
-    mappings("net.legacyfabric:yarn:1.8.9+build.532:v2")
+    mappings("net.legacyfabric:yarn:1.8.9+build.535:v2")
 
     modImplementation("net.legacyfabric.legacy-fabric-api:legacy-fabric-api:1.9.1+1.8.9")
     modImplementation("io.github.boogiemonster1o1:rewoven-modmenu:1.0.0+1.8.9") {


### PR DESCRIPTION
1. Updates ben-manes' versions dependency to 0.51.0,
2. Changes the `javaVersions` statement to have java be 17 instead of 18 as JDK 18 is EOL,
3. Bumps 1.8.9's yarn to 535.

And to finish it off - ViaFabric 0.4.12 becomes 0.4.13.