### PR TITLE
ViaVersion to 4.9.4-SNAPSHOT and some other things

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,4 +1,4 @@
-name: build
+name: Java CI with Gradle
 on: [ pull_request, push ]
 
 jobs:

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,4 +1,4 @@
-name: publish
+name: Publish to CurseForge and Modrinth
 on: [workflow_dispatch] # Manual trigger
 
 jobs:

--- a/build.gradle
+++ b/build.gradle
@@ -9,7 +9,7 @@ import java.util.stream.IntStream
 plugins {
     id "java"
     id "maven-publish"
-    id "org.ajoberstar.grgit" version "5.2.1"
+    id "org.ajoberstar.grgit" version "5.2.2"
     id "com.matthewprenger.cursegradle" version "1.4.0"
     id "com.modrinth.minotaur" version "2.8.7"
     id "fabric-loom" version "1.5-SNAPSHOT" apply false

--- a/gradle.properties
+++ b/gradle.properties
@@ -2,7 +2,7 @@
 org.gradle.jvmargs=-Xms32M -Xmx4G -XX:+UseG1GC -XX:+UseStringDeduplication
 
 loader_version=0.15.7
-viaver_version=4.9.3
+viaver_version=4.9.4-SNAPSHOT
 yaml_version=2.2
 
 publish_mc_versions=1.20.4, 1.19.4, 1.18.2, 1.17.1, 1.16.5, 1.15.2, 1.14.4, 1.12.2, 1.8.9

--- a/viafabric-mc112/build.gradle.kts
+++ b/viafabric-mc112/build.gradle.kts
@@ -2,7 +2,7 @@ dependencies {
     minecraft("com.mojang:minecraft:1.12.2")
     mappings("net.legacyfabric:yarn:1.12.2+build.541:v2")
 
-    modImplementation("net.legacyfabric.legacy-fabric-api:legacy-fabric-api:1.9.2")
+    modImplementation("net.legacyfabric.legacy-fabric-api:legacy-fabric-api:1.9.2+1.12.2")
 
     // fix newer java
     @Suppress("GradlePackageUpdate", "RedundantSuppression")

--- a/viafabric-mc112/build.gradle.kts
+++ b/viafabric-mc112/build.gradle.kts
@@ -1,8 +1,8 @@
 dependencies {
     minecraft("com.mojang:minecraft:1.12.2")
-    mappings("net.legacyfabric:yarn:1.12.2+build.535:v2")
+    mappings("net.legacyfabric:yarn:1.12.2+build.541:v2")
 
-    modImplementation("net.legacyfabric.legacy-fabric-api:legacy-fabric-api:1.9.1+1.12.2")
+    modImplementation("net.legacyfabric.legacy-fabric-api:legacy-fabric-api:1.9.2")
 
     // fix newer java
     @Suppress("GradlePackageUpdate", "RedundantSuppression")

--- a/viafabric-mc112/build.gradle.kts
+++ b/viafabric-mc112/build.gradle.kts
@@ -2,7 +2,7 @@ dependencies {
     minecraft("com.mojang:minecraft:1.12.2")
     mappings("net.legacyfabric:yarn:1.12.2+build.541:v2")
 
-    modImplementation("net.legacyfabric.legacy-fabric-api:legacy-fabric-api:1.9.2+1.12.2")
+    modImplementation("net.legacyfabric.legacy-fabric-api:legacy-fabric-api:1.9.3+1.12.2")
 
     // fix newer java
     @Suppress("GradlePackageUpdate", "RedundantSuppression")

--- a/viafabric-mc118/build.gradle.kts
+++ b/viafabric-mc118/build.gradle.kts
@@ -2,7 +2,7 @@ dependencies {
     minecraft("com.mojang:minecraft:1.18.2")
     mappings("net.fabricmc:yarn:1.18.2+build.4:v2")
 
-    modImplementation("net.fabricmc.fabric-api:fabric-api:0.76.0+1.18.2")
+    modImplementation("net.fabricmc.fabric-api:fabric-api:0.77.0+1.18.2")
     modImplementation("com.terraformersmc:modmenu:3.2.5")
 }
 

--- a/viafabric-mc119/build.gradle.kts
+++ b/viafabric-mc119/build.gradle.kts
@@ -2,7 +2,7 @@ dependencies {
     minecraft("com.mojang:minecraft:1.19.4")
     mappings("net.fabricmc:yarn:1.19.4+build.2:v2")
 
-    modImplementation("net.fabricmc.fabric-api:fabric-api:0.87.0+1.19.4")
+    modImplementation("net.fabricmc.fabric-api:fabric-api:0.87.2+1.19.4")
     modImplementation("com.terraformersmc:modmenu:6.3.1")
 }
 

--- a/viafabric-mc120/build.gradle.kts
+++ b/viafabric-mc120/build.gradle.kts
@@ -2,7 +2,7 @@ dependencies {
     minecraft("com.mojang:minecraft:1.20.4")
     mappings("net.fabricmc:yarn:1.20.4+build.3:v2")
 
-    modImplementation("net.fabricmc.fabric-api:fabric-api:0.96.1+1.20.4")
+    modImplementation("net.fabricmc.fabric-api:fabric-api:0.96.4+1.20.4")
     modImplementation("com.terraformersmc:modmenu:9.0.0")
 }
 

--- a/viafabric-mc18/build.gradle.kts
+++ b/viafabric-mc18/build.gradle.kts
@@ -2,7 +2,7 @@ dependencies {
     minecraft("com.mojang:minecraft:1.8.9")
     mappings("net.legacyfabric:yarn:1.8.9+build.541:v2")
 
-    modImplementation("net.legacyfabric.legacy-fabric-api:legacy-fabric-api:1.9.2")
+    modImplementation("net.legacyfabric.legacy-fabric-api:legacy-fabric-api:1.9.2+1.8.9")
     modImplementation("io.github.boogiemonster1o1:rewoven-modmenu:1.0.0+1.8.9") {
         isTransitive = false
     }

--- a/viafabric-mc18/build.gradle.kts
+++ b/viafabric-mc18/build.gradle.kts
@@ -2,7 +2,7 @@ dependencies {
     minecraft("com.mojang:minecraft:1.8.9")
     mappings("net.legacyfabric:yarn:1.8.9+build.541:v2")
 
-    modImplementation("net.legacyfabric.legacy-fabric-api:legacy-fabric-api:1.9.2+1.8.9")
+    modImplementation("net.legacyfabric.legacy-fabric-api:legacy-fabric-api:1.9.3+1.8.9")
     modImplementation("io.github.boogiemonster1o1:rewoven-modmenu:1.0.0+1.8.9") {
         isTransitive = false
     }

--- a/viafabric-mc18/build.gradle.kts
+++ b/viafabric-mc18/build.gradle.kts
@@ -1,8 +1,8 @@
 dependencies {
     minecraft("com.mojang:minecraft:1.8.9")
-    mappings("net.legacyfabric:yarn:1.8.9+build.535:v2")
+    mappings("net.legacyfabric:yarn:1.8.9+build.541:v2")
 
-    modImplementation("net.legacyfabric.legacy-fabric-api:legacy-fabric-api:1.9.1+1.8.9")
+    modImplementation("net.legacyfabric.legacy-fabric-api:legacy-fabric-api:1.9.2")
     modImplementation("io.github.boogiemonster1o1:rewoven-modmenu:1.0.0+1.8.9") {
         isTransitive = false
     }


### PR DESCRIPTION
1. Changes the titles of both CI scripts to properly clarify what they are meant for,
2. Updates grgit to 5.2.2,
3. Updates ViaVersion to 4.9.4-SNAPSHOT,
4. Bumps the yarn and fabric api for specific Minecraft versions to their latest counter-parts.

Some other notes i wanna point out although aren't part of this PR:

1. CurseGradle is archived on GitHub meaning it is no longer maintained in any way,
2. The VIA icon has inconsistent sizes when comparing the 3 built-in resource packs in 1.20.4,
3. Maybe add hangarmc support in future?