### PR TITLE
Loom 1.6, Update loader and API

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -12,7 +12,7 @@ plugins {
     id "org.ajoberstar.grgit" version "5.2.2"
     id "com.matthewprenger.cursegradle" version "1.4.0"
     id "com.modrinth.minotaur" version "2.8.7"
-    id "fabric-loom" version "1.5-SNAPSHOT" apply false
+    id "fabric-loom" version "1.6-SNAPSHOT" apply false
     id "com.github.ben-manes.versions" version "0.51.0"
 }
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,7 +1,7 @@
 # suppress inspection "UnusedProperty" for whole file
 org.gradle.jvmargs=-Xms32M -Xmx4G -XX:+UseG1GC -XX:+UseStringDeduplication
 
-loader_version=0.15.7
+loader_version=0.15.10
 viaver_version=4.9.4-SNAPSHOT
 yaml_version=2.2
 

--- a/viafabric-mc120/build.gradle.kts
+++ b/viafabric-mc120/build.gradle.kts
@@ -2,7 +2,7 @@ dependencies {
     minecraft("com.mojang:minecraft:1.20.4")
     mappings("net.fabricmc:yarn:1.20.4+build.3:v2")
 
-    modImplementation("net.fabricmc.fabric-api:fabric-api:0.96.4+1.20.4")
+    modImplementation("net.fabricmc.fabric-api:fabric-api:0.97.0+1.20.4")
     modImplementation("com.terraformersmc:modmenu:9.0.0")
 }
 


### PR DESCRIPTION
1. Updates API to 0.97.0 in mc120 directory,
2. Updates Fabric loader to 0.15.10 which also bumps Mixin dependency,
3. Updates Fabric Loom to 1.6. *(This one requires testing before merging)*