### PR TITLE
Ensure the 1.20.6 mixins use Java 21 in compatibility level

### DIFF
--- a/viafabric-mc1206/src/main/resources/mixins.viafabric1206.address.json
+++ b/viafabric-mc1206/src/main/resources/mixins.viafabric1206.address.json
@@ -1,6 +1,6 @@
 {
   "required": true,
-  "compatibilityLevel": "JAVA_17",
+  "compatibilityLevel": "JAVA_21",
   "package": "com.viaversion.fabric.mc1206.mixin.address",
   "mixins": [
   ],

--- a/viafabric-mc1206/src/main/resources/mixins.viafabric1206.debug.json
+++ b/viafabric-mc1206/src/main/resources/mixins.viafabric1206.debug.json
@@ -1,6 +1,6 @@
 {
   "required": true,
-  "compatibilityLevel": "JAVA_17",
+  "compatibilityLevel": "JAVA_21",
   "package": "com.viaversion.fabric.mc1206.mixin.debug",
   "mixins": [
   ],

--- a/viafabric-mc1206/src/main/resources/mixins.viafabric1206.gui.json
+++ b/viafabric-mc1206/src/main/resources/mixins.viafabric1206.gui.json
@@ -1,6 +1,6 @@
 {
   "required": true,
-  "compatibilityLevel": "JAVA_17",
+  "compatibilityLevel": "JAVA_21",
   "package": "com.viaversion.fabric.mc1206.mixin.gui",
   "mixins": [
   ],

--- a/viafabric-mc1206/src/main/resources/mixins.viafabric1206.pipeline.json
+++ b/viafabric-mc1206/src/main/resources/mixins.viafabric1206.pipeline.json
@@ -1,6 +1,6 @@
 {
   "required": true,
-  "compatibilityLevel": "JAVA_17",
+  "compatibilityLevel": "JAVA_21",
   "package": "com.viaversion.fabric.mc1206.mixin.pipeline",
   "mixins": [
     "MixinClientConnection"


### PR DESCRIPTION
Since Java 17 is no longer used in 1.20.5/1.20.6, The mixins should utilize Java 21 instead in terms of compatibility level.