### PR TITLE
Ensure ViaManager is destroyed on the server on graceful shutdown

### DIFF
--- a/viafabric-mc1122/src/main/java/com/viaversion/fabric/mc1122/mixin/shutdown/server/MixinMinecraftServer.java
+++ b/viafabric-mc1122/src/main/java/com/viaversion/fabric/mc1122/mixin/shutdown/server/MixinMinecraftServer.java
@@ -1,0 +1,34 @@
+/*
+ * This file is part of ViaFabric - https://github.com/ViaVersion/ViaFabric
+ * Copyright (C) 2018-2024 ViaVersion and contributors
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package com.viaversion.fabric.mc1122.mixin.shutdown.server;
+
+import com.viaversion.viaversion.ViaManagerImpl;
+import com.viaversion.viaversion.api.Via;
+import net.minecraft.server.MinecraftServer;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
+
+@Mixin(MinecraftServer.class)
+public class MixinMinecraftServer {
+    @Inject(method = "stopRunning", at = @At("TAIL"))
+    private void onStopRunning(CallbackInfo ci) {
+        ((ViaManagerImpl) Via.getManager()).destroy();
+    }
+}

--- a/viafabric-mc1122/src/main/resources/fabric.mod.json
+++ b/viafabric-mc1122/src/main/resources/fabric.mod.json
@@ -54,6 +54,7 @@
     "mixins.viafabric1122.address.json",
     "mixins.viafabric1122.gui.json",
     "mixins.viafabric1122.debug.json",
-    "mixins.viafabric1122.pipeline.json"
+    "mixins.viafabric1122.pipeline.json",
+    "mixins.viafabric1122.shutdown.json"
   ]
 }

--- a/viafabric-mc1122/src/main/resources/mixins.viafabric1122.shutdown.json
+++ b/viafabric-mc1122/src/main/resources/mixins.viafabric1122.shutdown.json
@@ -1,0 +1,13 @@
+{
+  "required": true,
+  "compatibilityLevel": "JAVA_8",
+  "package": "com.viaversion.fabric.mc1122.mixin.shutdown",
+  "mixins": [
+  ],
+  "server": [
+    "server.MixinMinecraftServer"
+  ],
+  "injectors": {
+    "defaultRequire": 0
+  }
+}

--- a/viafabric-mc1144/src/main/java/com/viaversion/fabric/mc1144/mixin/shutdown/server/MixinMinecraftServer.java
+++ b/viafabric-mc1144/src/main/java/com/viaversion/fabric/mc1144/mixin/shutdown/server/MixinMinecraftServer.java
@@ -1,0 +1,34 @@
+/*
+ * This file is part of ViaFabric - https://github.com/ViaVersion/ViaFabric
+ * Copyright (C) 2018-2024 ViaVersion and contributors
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package com.viaversion.fabric.mc1144.mixin.shutdown.server;
+
+import com.viaversion.viaversion.ViaManagerImpl;
+import com.viaversion.viaversion.api.Via;
+import net.minecraft.server.MinecraftServer;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
+
+@Mixin(MinecraftServer.class)
+public class MixinMinecraftServer {
+    @Inject(method = "stop", at = @At("TAIL"))
+    private void onStop(CallbackInfo ci) {
+        ((ViaManagerImpl) Via.getManager()).destroy();
+    }
+}

--- a/viafabric-mc1144/src/main/resources/fabric.mod.json
+++ b/viafabric-mc1144/src/main/resources/fabric.mod.json
@@ -69,7 +69,8 @@
     "mixins.viafabric1144.address.json",
     "mixins.viafabric1144.gui.json",
     "mixins.viafabric1144.debug.json",
-    "mixins.viafabric1144.pipeline.json"
+    "mixins.viafabric1144.pipeline.json",
+    "mixins.viafabric1144.shutdown.json"
   ],
   "custom": {
     "modmenu": {

--- a/viafabric-mc1144/src/main/resources/mixins.viafabric1144.shutdown.json
+++ b/viafabric-mc1144/src/main/resources/mixins.viafabric1144.shutdown.json
@@ -1,0 +1,13 @@
+{
+  "required": true,
+  "compatibilityLevel": "JAVA_8",
+  "package": "com.viaversion.fabric.mc1144.mixin.shutdown",
+  "mixins": [
+  ],
+  "server": [
+    "server.MixinMinecraftServer"
+  ],
+  "injectors": {
+    "defaultRequire": 0
+  }
+}

--- a/viafabric-mc1165/src/main/java/com/viaversion/fabric/mc1165/mixin/shutdown/server/MixinMinecraftServer.java
+++ b/viafabric-mc1165/src/main/java/com/viaversion/fabric/mc1165/mixin/shutdown/server/MixinMinecraftServer.java
@@ -1,0 +1,34 @@
+/*
+ * This file is part of ViaFabric - https://github.com/ViaVersion/ViaFabric
+ * Copyright (C) 2018-2024 ViaVersion and contributors
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package com.viaversion.fabric.mc1165.mixin.shutdown.server;
+
+import com.viaversion.viaversion.ViaManagerImpl;
+import com.viaversion.viaversion.api.Via;
+import net.minecraft.server.MinecraftServer;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
+
+@Mixin(MinecraftServer.class)
+public class MixinMinecraftServer {
+    @Inject(method = "stop", at = @At("TAIL"))
+    private void onStop(CallbackInfo ci) {
+        ((ViaManagerImpl) Via.getManager()).destroy();
+    }
+}

--- a/viafabric-mc1165/src/main/resources/fabric.mod.json
+++ b/viafabric-mc1165/src/main/resources/fabric.mod.json
@@ -65,7 +65,8 @@
     "mixins.viafabric1165.address.json",
     "mixins.viafabric1165.gui.json",
     "mixins.viafabric1165.debug.json",
-    "mixins.viafabric1165.pipeline.json"
+    "mixins.viafabric1165.pipeline.json",
+    "mixins.viafabric1165.shutdown.json"
   ],
   "custom": {
     "modmenu": {

--- a/viafabric-mc1165/src/main/resources/mixins.viafabric1165.shutdown.json
+++ b/viafabric-mc1165/src/main/resources/mixins.viafabric1165.shutdown.json
@@ -1,0 +1,13 @@
+{
+  "required": true,
+  "compatibilityLevel": "JAVA_8",
+  "package": "com.viaversion.fabric.mc1165.mixin.shutdown",
+  "mixins": [
+  ],
+  "server": [
+    "server.MixinMinecraftServer"
+  ],
+  "injectors": {
+    "defaultRequire": 0
+  }
+}

--- a/viafabric-mc1171/src/main/java/com/viaversion/fabric/mc1171/mixin/shutdown/server/MixinMinecraftServer.java
+++ b/viafabric-mc1171/src/main/java/com/viaversion/fabric/mc1171/mixin/shutdown/server/MixinMinecraftServer.java
@@ -1,0 +1,34 @@
+/*
+ * This file is part of ViaFabric - https://github.com/ViaVersion/ViaFabric
+ * Copyright (C) 2018-2024 ViaVersion and contributors
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package com.viaversion.fabric.mc1171.mixin.shutdown.server;
+
+import com.viaversion.viaversion.ViaManagerImpl;
+import com.viaversion.viaversion.api.Via;
+import net.minecraft.server.MinecraftServer;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
+
+@Mixin(MinecraftServer.class)
+public class MixinMinecraftServer {
+    @Inject(method = "stop", at = @At("TAIL"))
+    private void onStop(CallbackInfo ci) {
+        ((ViaManagerImpl) Via.getManager()).destroy();
+    }
+}

--- a/viafabric-mc1171/src/main/resources/fabric.mod.json
+++ b/viafabric-mc1171/src/main/resources/fabric.mod.json
@@ -68,7 +68,8 @@
     "mixins.viafabric1171.address.json",
     "mixins.viafabric1171.gui.json",
     "mixins.viafabric1171.debug.json",
-    "mixins.viafabric1171.pipeline.json"
+    "mixins.viafabric1171.pipeline.json",
+    "mixins.viafabric1171.shutdown.json"
   ],
   "custom": {
     "modmenu": {

--- a/viafabric-mc1171/src/main/resources/mixins.viafabric1171.shutdown.json
+++ b/viafabric-mc1171/src/main/resources/mixins.viafabric1171.shutdown.json
@@ -1,0 +1,13 @@
+{
+  "required": true,
+  "compatibilityLevel": "JAVA_16",
+  "package": "com.viaversion.fabric.mc1171.mixin.shutdown",
+  "mixins": [
+  ],
+  "server": [
+    "server.MixinMinecraftServer"
+  ],
+  "injectors": {
+    "defaultRequire": 0
+  }
+}

--- a/viafabric-mc1182/src/main/java/com/viaversion/fabric/mc1182/mixin/shutdown/server/MixinMinecraftServer.java
+++ b/viafabric-mc1182/src/main/java/com/viaversion/fabric/mc1182/mixin/shutdown/server/MixinMinecraftServer.java
@@ -1,0 +1,34 @@
+/*
+ * This file is part of ViaFabric - https://github.com/ViaVersion/ViaFabric
+ * Copyright (C) 2018-2024 ViaVersion and contributors
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package com.viaversion.fabric.mc1182.mixin.shutdown.server;
+
+import com.viaversion.viaversion.ViaManagerImpl;
+import com.viaversion.viaversion.api.Via;
+import net.minecraft.server.MinecraftServer;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
+
+@Mixin(MinecraftServer.class)
+public class MixinMinecraftServer {
+    @Inject(method = "stop", at = @At("TAIL"))
+    private void onStop(CallbackInfo ci) {
+        ((ViaManagerImpl) Via.getManager()).destroy();
+    }
+}

--- a/viafabric-mc1182/src/main/resources/fabric.mod.json
+++ b/viafabric-mc1182/src/main/resources/fabric.mod.json
@@ -68,7 +68,8 @@
     "mixins.viafabric1182.address.json",
     "mixins.viafabric1182.gui.json",
     "mixins.viafabric1182.debug.json",
-    "mixins.viafabric1182.pipeline.json"
+    "mixins.viafabric1182.pipeline.json",
+    "mixins.viafabric1182.shutdown.json"
   ],
   "custom": {
     "modmenu": {

--- a/viafabric-mc1182/src/main/resources/mixins.viafabric1182.shutdown.json
+++ b/viafabric-mc1182/src/main/resources/mixins.viafabric1182.shutdown.json
@@ -1,0 +1,13 @@
+{
+  "required": true,
+  "compatibilityLevel": "JAVA_17",
+  "package": "com.viaversion.fabric.mc1182.mixin.shutdown",
+  "mixins": [
+  ],
+  "server": [
+    "server.MixinMinecraftServer"
+  ],
+  "injectors": {
+    "defaultRequire": 0
+  }
+}

--- a/viafabric-mc1194/src/main/java/com/viaversion/fabric/mc1194/mixin/shutdown/server/MixinMinecraftServer.java
+++ b/viafabric-mc1194/src/main/java/com/viaversion/fabric/mc1194/mixin/shutdown/server/MixinMinecraftServer.java
@@ -1,0 +1,34 @@
+/*
+ * This file is part of ViaFabric - https://github.com/ViaVersion/ViaFabric
+ * Copyright (C) 2018-2024 ViaVersion and contributors
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package com.viaversion.fabric.mc1194.mixin.shutdown.server;
+
+import com.viaversion.viaversion.ViaManagerImpl;
+import com.viaversion.viaversion.api.Via;
+import net.minecraft.server.MinecraftServer;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
+
+@Mixin(MinecraftServer.class)
+public class MixinMinecraftServer {
+    @Inject(method = "stop", at = @At("TAIL"))
+    private void onStop(CallbackInfo ci) {
+        ((ViaManagerImpl) Via.getManager()).destroy();
+    }
+}

--- a/viafabric-mc1194/src/main/resources/fabric.mod.json
+++ b/viafabric-mc1194/src/main/resources/fabric.mod.json
@@ -68,7 +68,8 @@
     "mixins.viafabric1194.address.json",
     "mixins.viafabric1194.gui.json",
     "mixins.viafabric1194.debug.json",
-    "mixins.viafabric1194.pipeline.json"
+    "mixins.viafabric1194.pipeline.json",
+    "mixins.viafabric1194.shutdown.json"
   ],
   "custom": {
     "modmenu": {

--- a/viafabric-mc1194/src/main/resources/mixins.viafabric1194.shutdown.json
+++ b/viafabric-mc1194/src/main/resources/mixins.viafabric1194.shutdown.json
@@ -1,0 +1,13 @@
+{
+  "required": true,
+  "compatibilityLevel": "JAVA_17",
+  "package": "com.viaversion.fabric.mc1194.mixin.shutdown",
+  "mixins": [
+  ],
+  "server": [
+    "server.MixinMinecraftServer"
+  ],
+  "injectors": {
+    "defaultRequire": 0
+  }
+}

--- a/viafabric-mc1201/src/main/java/com/viaversion/fabric/mc1201/mixin/shutdown/server/MixinMinecraftServer.java
+++ b/viafabric-mc1201/src/main/java/com/viaversion/fabric/mc1201/mixin/shutdown/server/MixinMinecraftServer.java
@@ -1,0 +1,34 @@
+/*
+ * This file is part of ViaFabric - https://github.com/ViaVersion/ViaFabric
+ * Copyright (C) 2018-2024 ViaVersion and contributors
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package com.viaversion.fabric.mc1201.mixin.shutdown.server;
+
+import com.viaversion.viaversion.ViaManagerImpl;
+import com.viaversion.viaversion.api.Via;
+import net.minecraft.server.MinecraftServer;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
+
+@Mixin(MinecraftServer.class)
+public class MixinMinecraftServer {
+    @Inject(method = "stop", at = @At("TAIL"))
+    private void onStop(CallbackInfo ci) {
+        ((ViaManagerImpl) Via.getManager()).destroy();
+    }
+}

--- a/viafabric-mc1201/src/main/resources/fabric.mod.json
+++ b/viafabric-mc1201/src/main/resources/fabric.mod.json
@@ -68,7 +68,8 @@
     "mixins.viafabric1201.address.json",
     "mixins.viafabric1201.gui.json",
     "mixins.viafabric1201.debug.json",
-    "mixins.viafabric1201.pipeline.json"
+    "mixins.viafabric1201.pipeline.json",
+    "mixins.viafabric1201.shutdown.json"
   ],
   "custom": {
     "modmenu": {

--- a/viafabric-mc1201/src/main/resources/mixins.viafabric1201.shutdown.json
+++ b/viafabric-mc1201/src/main/resources/mixins.viafabric1201.shutdown.json
@@ -1,0 +1,13 @@
+{
+  "required": true,
+  "compatibilityLevel": "JAVA_17",
+  "package": "com.viaversion.fabric.mc1201.mixin.shutdown",
+  "mixins": [
+  ],
+  "server": [
+    "server.MixinMinecraftServer"
+  ],
+  "injectors": {
+    "defaultRequire": 0
+  }
+}

--- a/viafabric-mc1204/src/main/java/com/viaversion/fabric/mc1204/mixin/shutdown/server/MixinMinecraftServer.java
+++ b/viafabric-mc1204/src/main/java/com/viaversion/fabric/mc1204/mixin/shutdown/server/MixinMinecraftServer.java
@@ -1,0 +1,34 @@
+/*
+ * This file is part of ViaFabric - https://github.com/ViaVersion/ViaFabric
+ * Copyright (C) 2018-2024 ViaVersion and contributors
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package com.viaversion.fabric.mc1204.mixin.shutdown.server;
+
+import com.viaversion.viaversion.ViaManagerImpl;
+import com.viaversion.viaversion.api.Via;
+import net.minecraft.server.MinecraftServer;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
+
+@Mixin(MinecraftServer.class)
+public class MixinMinecraftServer {
+    @Inject(method = "stop", at = @At("TAIL"))
+    private void onStop(CallbackInfo ci) {
+        ((ViaManagerImpl) Via.getManager()).destroy();
+    }
+}

--- a/viafabric-mc1204/src/main/resources/fabric.mod.json
+++ b/viafabric-mc1204/src/main/resources/fabric.mod.json
@@ -68,7 +68,8 @@
     "mixins.viafabric1204.address.json",
     "mixins.viafabric1204.gui.json",
     "mixins.viafabric1204.debug.json",
-    "mixins.viafabric1204.pipeline.json"
+    "mixins.viafabric1204.pipeline.json",
+    "mixins.viafabric1204.shutdown.json"
   ],
   "custom": {
     "modmenu": {

--- a/viafabric-mc1204/src/main/resources/mixins.viafabric1204.shutdown.json
+++ b/viafabric-mc1204/src/main/resources/mixins.viafabric1204.shutdown.json
@@ -1,0 +1,13 @@
+{
+  "required": true,
+  "compatibilityLevel": "JAVA_17",
+  "package": "com.viaversion.fabric.mc1204.mixin.shutdown",
+  "mixins": [
+  ],
+  "server": [
+    "server.MixinMinecraftServer"
+  ],
+  "injectors": {
+    "defaultRequire": 0
+  }
+}

--- a/viafabric-mc1206/src/main/java/com/viaversion/fabric/mc1206/mixin/shutdown/server/MixinMinecraftServer.java
+++ b/viafabric-mc1206/src/main/java/com/viaversion/fabric/mc1206/mixin/shutdown/server/MixinMinecraftServer.java
@@ -1,0 +1,34 @@
+/*
+ * This file is part of ViaFabric - https://github.com/ViaVersion/ViaFabric
+ * Copyright (C) 2018-2024 ViaVersion and contributors
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package com.viaversion.fabric.mc1206.mixin.shutdown.server;
+
+import com.viaversion.viaversion.ViaManagerImpl;
+import com.viaversion.viaversion.api.Via;
+import net.minecraft.server.MinecraftServer;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
+
+@Mixin(MinecraftServer.class)
+public class MixinMinecraftServer {
+    @Inject(method = "stop", at = @At("TAIL"))
+    private void onStop(CallbackInfo ci) {
+        ((ViaManagerImpl) Via.getManager()).destroy();
+    }
+}

--- a/viafabric-mc1206/src/main/resources/fabric.mod.json
+++ b/viafabric-mc1206/src/main/resources/fabric.mod.json
@@ -68,7 +68,8 @@
     "mixins.viafabric1206.address.json",
     "mixins.viafabric1206.gui.json",
     "mixins.viafabric1206.debug.json",
-    "mixins.viafabric1206.pipeline.json"
+    "mixins.viafabric1206.pipeline.json",
+    "mixins.viafabric1206.shutdown.json"
   ],
   "custom": {
     "modmenu": {

--- a/viafabric-mc1206/src/main/resources/mixins.viafabric1206.shutdown.json
+++ b/viafabric-mc1206/src/main/resources/mixins.viafabric1206.shutdown.json
@@ -1,0 +1,13 @@
+{
+  "required": true,
+  "compatibilityLevel": "JAVA_21",
+  "package": "com.viaversion.fabric.mc1206.mixin.shutdown",
+  "mixins": [
+  ],
+  "server": [
+    "server.MixinMinecraftServer"
+  ],
+  "injectors": {
+    "defaultRequire": 0
+  }
+}

--- a/viafabric-mc189/src/main/java/com/viaversion/fabric/mc189/mixin/shutdown/server/MixinMinecraftServer.java
+++ b/viafabric-mc189/src/main/java/com/viaversion/fabric/mc189/mixin/shutdown/server/MixinMinecraftServer.java
@@ -1,0 +1,34 @@
+/*
+ * This file is part of ViaFabric - https://github.com/ViaVersion/ViaFabric
+ * Copyright (C) 2018-2024 ViaVersion and contributors
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package com.viaversion.fabric.mc189.mixin.shutdown.server;
+
+import com.viaversion.viaversion.ViaManagerImpl;
+import com.viaversion.viaversion.api.Via;
+import net.minecraft.server.MinecraftServer;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
+
+@Mixin(MinecraftServer.class)
+public class MixinMinecraftServer {
+    @Inject(method = "stopRunning", at = @At("TAIL"))
+    private void onStopRunning(CallbackInfo ci) {
+        ((ViaManagerImpl) Via.getManager()).destroy();
+    }
+}

--- a/viafabric-mc189/src/main/resources/fabric.mod.json
+++ b/viafabric-mc189/src/main/resources/fabric.mod.json
@@ -65,7 +65,8 @@
     "mixins.viafabric189.address.json",
     "mixins.viafabric189.gui.json",
     "mixins.viafabric189.debug.json",
-    "mixins.viafabric189.pipeline.json"
+    "mixins.viafabric189.pipeline.json",
+    "mixins.viafabric189.shutdown.json"
   ],
   "custom": {
     "modmenu": {

--- a/viafabric-mc189/src/main/resources/mixins.viafabric189.shutdown.json
+++ b/viafabric-mc189/src/main/resources/mixins.viafabric189.shutdown.json
@@ -1,0 +1,13 @@
+{
+  "required": true,
+  "compatibilityLevel": "JAVA_8",
+  "package": "com.viaversion.fabric.mc189.mixin.shutdown",
+  "mixins": [
+  ],
+  "server": [
+    "server.MixinMinecraftServer"
+  ],
+  "injectors": {
+    "defaultRequire": 0
+  }
+}


### PR DESCRIPTION
In my testing with 1.20.6 and the latest snapshots versions of ViaVersion/ViaBackwards/ViaRewind (as detailed in the original issue) available on Hangar, this should fix #327. 

A similar fix may be required for legacy client versions, but on the 1.20.6 client with the snapshot versions of ViaVersion/ViaBackwards/ViaRewind this issue doesn't seem to occur.