### PR TITLE
Update Loader to 0.15.11, ViaVersion 4.10.2

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,8 +1,8 @@
 # suppress inspection "UnusedProperty" for whole file
 org.gradle.jvmargs=-Xms32M -Xmx4G -XX:+UseG1GC -XX:+UseStringDeduplication
 
-loader_version=0.15.10
-viaver_version=4.10.1
+loader_version=0.15.11
+viaver_version=4.10.2
 yaml_version=2.2
 
 publish_mc_versions=1.20.6, 1.20.4, 1.20.1, 1.19.4, 1.18.2, 1.17.1, 1.16.5, 1.15.2, 1.14.4, 1.12.2, 1.8.9


### PR DESCRIPTION
Some more extra bug fixes from viaversion itself, Loader 0.15.11 on other hand adds support for 1.21 snapshots.