### PR TITLE
Ubuntu 24.04, JDK 21.0.3 in JitPack, ViaVersion 4.10.3-SNAPSHOT

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -3,7 +3,7 @@ on: [ pull_request, push ]
 
 jobs:
   build:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     steps:
       - name: Checkout Repository
         uses: actions/checkout@v4

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -4,7 +4,7 @@ on: [workflow_dispatch] # Manual trigger
 jobs:
   publish:
     if: github.repository_owner == 'ViaVersion'
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     steps:
       - name: Checkout Repository
         uses: actions/checkout@v4

--- a/gradle.properties
+++ b/gradle.properties
@@ -2,7 +2,7 @@
 org.gradle.jvmargs=-Xms32M -Xmx4G -XX:+UseG1GC -XX:+UseStringDeduplication
 
 loader_version=0.15.11
-viaver_version=4.10.2
+viaver_version=4.10.3-SNAPSHOT
 yaml_version=2.2
 
 publish_mc_versions=1.20.6, 1.20.4, 1.20.1, 1.19.4, 1.18.2, 1.17.1, 1.16.5, 1.15.2, 1.14.4, 1.12.2, 1.8.9

--- a/jitpack.yml
+++ b/jitpack.yml
@@ -3,5 +3,5 @@
 before_install:
   - curl -s "https://get.sdkman.io" | bash
   - source ~/.sdkman/bin/sdkman-init.sh
-  - sdk install java 21.0.2-tem
-  - sdk use java 21.0.2-tem
+  - sdk install java 21.0.3-tem
+  - sdk use java 21.0.3-tem


### PR DESCRIPTION
1. Updates Ubuntu to 24.04 as GitHub released a [blog](https://github.blog/changelog/2024-05-14-github-hosted-runners-public-beta-of-ubuntu-24-04-is-now-available) stating that it is now a supported `runs-on` version,
2. Updates JDK to 21.0.3 for JitPack,
3. Updates ViaVersion to 4.10.3-SNAPSHOT so that invalid chunk entities are removed for 1.20.5/1.20.6 clients.