### PR TITLE
Upstream Mod Menu, Fabric API and Yarn, Add note for CurseGradle

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -10,7 +10,7 @@ plugins {
     id "java"
     id "maven-publish"
     id "org.ajoberstar.grgit" version "5.2.2"
-    id "com.matthewprenger.cursegradle" version "1.4.0"
+    id "com.matthewprenger.cursegradle" version "1.4.0" // This repository is archived on GH
     id "com.modrinth.minotaur" version "2.8.7"
     id "fabric-loom" version "1.6-SNAPSHOT" apply false
     id "com.github.ben-manes.versions" version "0.51.0"

--- a/viafabric-mc1122/build.gradle.kts
+++ b/viafabric-mc1122/build.gradle.kts
@@ -2,7 +2,7 @@ dependencies {
     minecraft("com.mojang:minecraft:1.12.2")
     mappings("net.legacyfabric:yarn:1.12.2+build.541:v2")
 
-    modImplementation("net.legacyfabric.legacy-fabric-api:legacy-fabric-api:1.9.3+1.12.2")
+    modImplementation("net.legacyfabric.legacy-fabric-api:legacy-fabric-api:1.9.4+1.12.2")
 
     // fix newer java
     @Suppress("GradlePackageUpdate", "RedundantSuppression")

--- a/viafabric-mc1201/build.gradle.kts
+++ b/viafabric-mc1201/build.gradle.kts
@@ -1,9 +1,9 @@
 dependencies {
     minecraft("com.mojang:minecraft:1.20.1")
-    mappings("net.fabricmc:yarn:1.20.1+build.2:v2")
+    mappings("net.fabricmc:yarn:1.20.1+build.10:v2")
 
-    modImplementation("net.fabricmc.fabric-api:fabric-api:0.83.1+1.20.1")
-    modImplementation("com.terraformersmc:modmenu:7.1.0")
+    modImplementation("net.fabricmc.fabric-api:fabric-api:0.92.1+1.20.1")
+    modImplementation("com.terraformersmc:modmenu:7.2.2")
 }
 
 tasks.compileJava {

--- a/viafabric-mc1206/build.gradle.kts
+++ b/viafabric-mc1206/build.gradle.kts
@@ -2,7 +2,7 @@ dependencies {
     minecraft("com.mojang:minecraft:1.20.6")
     mappings("net.fabricmc:yarn:1.20.6+build.1:v2")
 
-    modImplementation("net.fabricmc.fabric-api:fabric-api:0.97.8+1.20.6")
+    modImplementation("net.fabricmc.fabric-api:fabric-api:0.98.0+1.20.6")
     modImplementation("com.terraformersmc:modmenu:10.0.0-beta.1")
 }
 

--- a/viafabric-mc189/build.gradle.kts
+++ b/viafabric-mc189/build.gradle.kts
@@ -2,7 +2,7 @@ dependencies {
     minecraft("com.mojang:minecraft:1.8.9")
     mappings("net.legacyfabric:yarn:1.8.9+build.541:v2")
 
-    modImplementation("net.legacyfabric.legacy-fabric-api:legacy-fabric-api:1.9.3+1.8.9")
+    modImplementation("net.legacyfabric.legacy-fabric-api:legacy-fabric-api:1.9.4+1.8.9")
     modImplementation("io.github.boogiemonster1o1:rewoven-modmenu:1.0.0+1.8.9") {
         isTransitive = false
     }


### PR DESCRIPTION
1. Adds a note to CurseGradle stating that the repository is archived on GitHub,
2. Upstreams Yarn to build 10 for 1.20.1,
3. Upstreams Mod Menu to 7.2.2 for 1.20.1,
4. Upstreams Fabric API to 1.9.4 for both 1.8.9 and 1.12.2, 0.92.1 for 1.20.1 and 0.98.0 for 1.20.6.