### PR TITLE
BungeeCord->Velocity, Exclude NEC

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -25,7 +25,6 @@ body:
       description: |
         If you encounter warnings/errors in your console, **paste them with https://mclo.gs/ and put the paste link here**.
         If the error is small/less than 10 lines, you may put it directly into this field.
-        Please use Not Enough Crashes if possible, making the stacktrace easier to understand.
       value: |
         ```
         Put the mclo.gs link or text here.
@@ -72,9 +71,9 @@ body:
     attributes:
       label: Additional Server Info
       description: |
-        Does the server use a proxy (eg. BungeeCord)? What software are used and what plugins/mods (Check with F3 debug menu)? Are you using client-side mode?
+        Does the server use a proxy (eg. Velocity)? What software are used and what plugins/mods (Check with F3 debug menu)? Are you using client-side mode?
       placeholder: |
-        Example: "I also use BungeeCord with the following plugins: x, y, z"
+        Example: "I also use Velocity with the following plugins: x, y, z"
     validations:
       required: false
 


### PR DESCRIPTION
1. Replaces the Bungeecord texts with Velocity instead as fabric servers do not run properly with bungeecord as the proxy and because bungeecord in general is just crap in reality,
2. Removes the Not Enough Crashes mod reference as it has caused problems with accuracy and ends up creating severe game crashes than it solves.