### PR TITLE
Add setting to ignore Fabric registry sync errors

### DIFF
--- a/src/main/java/com/viaversion/fabric/common/config/VFConfig.java
+++ b/src/main/java/com/viaversion/fabric/common/config/VFConfig.java
@@ -32,6 +32,7 @@ public class VFConfig extends Config {
     public static final String CLIENT_SIDE_VERSION = "client-side-version";
     public static final String CLIENT_SIDE_FORCE_DISABLE = "client-side-force-disable";
     public static final String HIDE_BUTTON = "hide-button";
+    public static final String IGNORE_REGISTRY_SYNC_ERRORS = "ignore-registry-sync-errors";
 
     public VFConfig(File configFile, Logger logger) {
         super(configFile, logger);
@@ -82,5 +83,9 @@ public class VFConfig extends Config {
 
     public boolean isForcedDisable(String line) {
         return getClientSideForceDisable().contains(line);
+    }
+
+    public boolean isIgnoreRegistrySyncErrors() {
+        return getBoolean(IGNORE_REGISTRY_SYNC_ERRORS, false);
     }
 }

--- a/src/main/resources/assets/viafabric/config.yml
+++ b/src/main/resources/assets/viafabric/config.yml
@@ -12,3 +12,5 @@ hide-button: false
 # This isn't always the address in multiplayer menu; It will use the SRV record pointer when present, Check the game log for the address.
 # Uses https://wiki.vg/Mojang_API#Blocked_Servers format (mc.example.com, *.example.com, 192.168.0.1, 192.168.*)
 client-side-force-disable: ["hypixel.net", "*.hypixel.net", "minemen.club", "*.minemen.club", "icantjoinlmfao.club"]
+# If enabled, Fabric registry synchronization errors on the client side will be ignored and prevented on the server side.
+ignore-registry-sync-errors: false

--- a/viafabric-mc1204/src/main/java/com/viaversion/fabric/mc1204/mixin/debug/MixinRegistrySyncManager.java
+++ b/viafabric-mc1204/src/main/java/com/viaversion/fabric/mc1204/mixin/debug/MixinRegistrySyncManager.java
@@ -1,0 +1,22 @@
+package com.viaversion.fabric.mc1204.mixin.debug;
+
+import com.viaversion.fabric.mc1204.ViaFabric;
+import net.fabricmc.fabric.impl.registry.sync.RegistrySyncManager;
+import net.minecraft.server.MinecraftServer;
+import net.minecraft.server.network.ServerConfigurationNetworkHandler;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
+
+@Mixin(value = RegistrySyncManager.class, remap = false)
+public class MixinRegistrySyncManager {
+
+    @Inject(method = "configureClient", at = @At("HEAD"), cancellable = true)
+    private static void ignoreMissingRegistries(ServerConfigurationNetworkHandler handler, MinecraftServer server, CallbackInfo ci) {
+        if (ViaFabric.config.isIgnoreRegistrySyncErrors()) {
+            ci.cancel();
+        }
+    }
+
+}

--- a/viafabric-mc1204/src/main/java/com/viaversion/fabric/mc1204/mixin/debug/client/MixinRegistrySyncManager.java
+++ b/viafabric-mc1204/src/main/java/com/viaversion/fabric/mc1204/mixin/debug/client/MixinRegistrySyncManager.java
@@ -1,0 +1,32 @@
+package com.viaversion.fabric.mc1204.mixin.debug.client;
+
+import com.viaversion.fabric.mc1204.ViaFabric;
+import it.unimi.dsi.fastutil.objects.Object2IntMap;
+import net.fabricmc.fabric.impl.registry.sync.RegistrySyncManager;
+import net.minecraft.util.Identifier;
+import org.slf4j.Logger;
+import org.spongepowered.asm.mixin.Final;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.Shadow;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
+
+import java.util.Map;
+
+@Mixin(value = RegistrySyncManager.class, remap = false)
+public class MixinRegistrySyncManager {
+
+    @Shadow
+    @Final
+    private static Logger LOGGER;
+
+    @Inject(method = "checkRemoteRemap", at = @At(value = "INVOKE", target = "Lorg/slf4j/Logger;error(Ljava/lang/String;)V", ordinal = 0), cancellable = true)
+    private static void ignoreMissingRegistries(Map<Identifier, Object2IntMap<Identifier>> map, CallbackInfo ci) {
+        if (ViaFabric.config.isIgnoreRegistrySyncErrors()) {
+            LOGGER.warn("Ignoring missing registries");
+            ci.cancel();
+        }
+    }
+
+}

--- a/viafabric-mc1204/src/main/resources/mixins.viafabric1204.debug.json
+++ b/viafabric-mc1204/src/main/resources/mixins.viafabric1204.debug.json
@@ -3,10 +3,12 @@
   "compatibilityLevel": "JAVA_17",
   "package": "com.viaversion.fabric.mc1204.mixin.debug",
   "mixins": [
+    "MixinRegistrySyncManager"
   ],
   "client": [
-    "client.MixinClientConnectionAccessor",
+    "client.MixinRegistrySyncManager",
     "client.MixinClientConnection",
+    "client.MixinClientConnectionAccessor",
     "client.MixinDebugHud"
   ],
   "injectors": {

--- a/viafabric-mc1206/src/main/java/com/viaversion/fabric/mc1206/mixin/debug/MixinRegistrySyncManager.java
+++ b/viafabric-mc1206/src/main/java/com/viaversion/fabric/mc1206/mixin/debug/MixinRegistrySyncManager.java
@@ -9,7 +9,7 @@ import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.Inject;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
 
-@Mixin(RegistrySyncManager.class)
+@Mixin(value = RegistrySyncManager.class, remap = false)
 public class MixinRegistrySyncManager {
 
     @Inject(method = "configureClient", at = @At("HEAD"), cancellable = true)

--- a/viafabric-mc1206/src/main/java/com/viaversion/fabric/mc1206/mixin/debug/MixinRegistrySyncManager.java
+++ b/viafabric-mc1206/src/main/java/com/viaversion/fabric/mc1206/mixin/debug/MixinRegistrySyncManager.java
@@ -1,0 +1,22 @@
+package com.viaversion.fabric.mc1206.mixin.debug;
+
+import com.viaversion.fabric.mc1206.ViaFabric;
+import net.fabricmc.fabric.impl.registry.sync.RegistrySyncManager;
+import net.minecraft.server.MinecraftServer;
+import net.minecraft.server.network.ServerConfigurationNetworkHandler;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
+
+@Mixin(RegistrySyncManager.class)
+public class MixinRegistrySyncManager {
+
+    @Inject(method = "configureClient", at = @At("HEAD"), cancellable = true)
+    private static void ignoreMissingRegistries(ServerConfigurationNetworkHandler handler, MinecraftServer server, CallbackInfo ci) {
+        if (ViaFabric.config.isIgnoreRegistrySyncErrors()) {
+            ci.cancel();
+        }
+    }
+
+}

--- a/viafabric-mc1206/src/main/java/com/viaversion/fabric/mc1206/mixin/debug/client/MixinRegistrySyncManager.java
+++ b/viafabric-mc1206/src/main/java/com/viaversion/fabric/mc1206/mixin/debug/client/MixinRegistrySyncManager.java
@@ -14,7 +14,7 @@ import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
 
 import java.util.Map;
 
-@Mixin(RegistrySyncManager.class)
+@Mixin(value = RegistrySyncManager.class, remap = false)
 public class MixinRegistrySyncManager {
 
     @Shadow

--- a/viafabric-mc1206/src/main/java/com/viaversion/fabric/mc1206/mixin/debug/client/MixinRegistrySyncManager.java
+++ b/viafabric-mc1206/src/main/java/com/viaversion/fabric/mc1206/mixin/debug/client/MixinRegistrySyncManager.java
@@ -1,0 +1,32 @@
+package com.viaversion.fabric.mc1206.mixin.debug.client;
+
+import com.viaversion.fabric.mc1206.ViaFabric;
+import it.unimi.dsi.fastutil.objects.Object2IntMap;
+import net.fabricmc.fabric.impl.registry.sync.RegistrySyncManager;
+import net.minecraft.util.Identifier;
+import org.slf4j.Logger;
+import org.spongepowered.asm.mixin.Final;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.Shadow;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
+
+import java.util.Map;
+
+@Mixin(RegistrySyncManager.class)
+public class MixinRegistrySyncManager {
+
+    @Shadow
+    @Final
+    private static Logger LOGGER;
+
+    @Inject(method = "checkRemoteRemap", at = @At(value = "INVOKE", target = "Lorg/slf4j/Logger;error(Ljava/lang/String;)V", ordinal = 0), cancellable = true)
+    private static void ignoreMissingRegistries(Map<Identifier, Object2IntMap<Identifier>> map, CallbackInfo ci) {
+        if (ViaFabric.config.isIgnoreRegistrySyncErrors()) {
+            LOGGER.warn("Ignoring missing registries");
+            ci.cancel();
+        }
+    }
+
+}

--- a/viafabric-mc1206/src/main/resources/mixins.viafabric1206.debug.json
+++ b/viafabric-mc1206/src/main/resources/mixins.viafabric1206.debug.json
@@ -3,10 +3,12 @@
   "compatibilityLevel": "JAVA_21",
   "package": "com.viaversion.fabric.mc1206.mixin.debug",
   "mixins": [
+    "MixinRegistrySyncManager"
   ],
   "client": [
-    "client.MixinClientConnectionAccessor",
+    "client.MixinRegistrySyncManager",
     "client.MixinClientConnection",
+    "client.MixinClientConnectionAccessor",
     "client.MixinDebugHud"
   ],
   "injectors": {


### PR DESCRIPTION
Adds a config option to ignore fabric registry errors on the client side and fully cancel any registry validation on the server side. If it should be added to any other sub modules, let me know.

Closes https://github.com/ViaVersion/ViaFabric/issues/309