### PR TITLE
Ensure 2.6.15 and older ReplayMod is not supported

### DIFF
--- a/src/main/resources/fabric.mod.json
+++ b/src/main/resources/fabric.mod.json
@@ -17,8 +17,7 @@
     "viaversion": ">=5.0.0"
   },
   "breaks": {
-    "viafabricplus": "*",
-    "replaymod": "*"
+    "viafabricplus": "*"
   },
   "environment": "*",
   "authors": [

--- a/viafabric-mc1144/src/main/resources/fabric.mod.json
+++ b/viafabric-mc1144/src/main/resources/fabric.mod.json
@@ -65,6 +65,9 @@
     "fabric-command-api-v1": "*",
     "cotton-client-commands": "*"
   },
+  "breaks": {
+    "replaymod": "<=1.14.4-2.6.15"
+  },
   "mixins": [
     "mixins.viafabric1144.address.json",
     "mixins.viafabric1144.gui.json",

--- a/viafabric-mc1152/src/main/resources/fabric.mod.json
+++ b/viafabric-mc1152/src/main/resources/fabric.mod.json
@@ -65,6 +65,9 @@
     "fabric-command-api-v1": "*",
     "cotton-client-commands": "*"
   },
+  "breaks": {
+    "replaymod": "<=1.15.2-2.6.15"
+  },
   "mixins": [
     "mixins.viafabric1152.address.json",
     "mixins.viafabric1152.gui.json",

--- a/viafabric-mc1165/src/main/resources/fabric.mod.json
+++ b/viafabric-mc1165/src/main/resources/fabric.mod.json
@@ -61,6 +61,9 @@
   "recommends": {
     "fabric-command-api-v1": "*"
   },
+  "breaks": {
+    "replaymod": "<=1.16.5-2.6.15"
+  },
   "mixins": [
     "mixins.viafabric1165.address.json",
     "mixins.viafabric1165.gui.json",

--- a/viafabric-mc1171/src/main/resources/fabric.mod.json
+++ b/viafabric-mc1171/src/main/resources/fabric.mod.json
@@ -64,6 +64,9 @@
   "recommends": {
     "fabric-command-api-v1": "*"
   },
+  "breaks": {
+    "replaymod": "<=1.17.1-2.6.15"
+  },
   "mixins": [
     "mixins.viafabric1171.address.json",
     "mixins.viafabric1171.gui.json",

--- a/viafabric-mc1182/src/main/resources/fabric.mod.json
+++ b/viafabric-mc1182/src/main/resources/fabric.mod.json
@@ -64,6 +64,9 @@
   "recommends": {
     "fabric-command-api-v1": "*"
   },
+  "breaks": {
+    "replaymod": "<=1.18.2-2.6.15"
+  },
   "mixins": [
     "mixins.viafabric1182.address.json",
     "mixins.viafabric1182.gui.json",

--- a/viafabric-mc1194/src/main/resources/fabric.mod.json
+++ b/viafabric-mc1194/src/main/resources/fabric.mod.json
@@ -64,6 +64,9 @@
   "recommends": {
     "fabric-command-api-v2": "*"
   },
+  "breaks": {
+    "replaymod": "<=1.19.4-2.6.15"
+  },
   "mixins": [
     "mixins.viafabric1194.address.json",
     "mixins.viafabric1194.gui.json",

--- a/viafabric-mc1201/src/main/resources/fabric.mod.json
+++ b/viafabric-mc1201/src/main/resources/fabric.mod.json
@@ -64,6 +64,9 @@
   "recommends": {
     "fabric-command-api-v2": "*"
   },
+  "breaks": {
+    "replaymod": "<=1.20.1-2.6.15"
+  },
   "mixins": [
     "mixins.viafabric1201.address.json",
     "mixins.viafabric1201.gui.json",

--- a/viafabric-mc1204/src/main/resources/fabric.mod.json
+++ b/viafabric-mc1204/src/main/resources/fabric.mod.json
@@ -64,6 +64,9 @@
   "recommends": {
     "fabric-command-api-v2": "*"
   },
+  "breaks": {
+    "replaymod": "<=1.20.4-2.6.15"
+  },
   "mixins": [
     "mixins.viafabric1204.address.json",
     "mixins.viafabric1204.gui.json",

--- a/viafabric-mc1206/src/main/resources/fabric.mod.json
+++ b/viafabric-mc1206/src/main/resources/fabric.mod.json
@@ -64,6 +64,9 @@
   "recommends": {
     "fabric-command-api-v2": "*"
   },
+  "breaks": {
+    "replaymod": "<=1.20.6-2.6.15"
+  },
   "mixins": [
     "mixins.viafabric1206.address.json",
     "mixins.viafabric1206.gui.json",

--- a/viafabric-mc121/src/main/resources/fabric.mod.json
+++ b/viafabric-mc121/src/main/resources/fabric.mod.json
@@ -64,6 +64,9 @@
   "recommends": {
     "fabric-command-api-v2": "*"
   },
+  "breaks": {
+    "replaymod": "<=1.21-2.6.15"
+  },
   "mixins": [
     "mixins.viafabric121.address.json",
     "mixins.viafabric121.gui.json",


### PR DESCRIPTION
Resolves #12 *(again)*

This PR blocks 2.6.15 and older ReplayMod builds from running as they cause the mappings to break entirely. 2.6.16 was tested and seems to work properly in 1.20.4 as example version, However testing is needed as the breaks statement is kinda ugly as i do not know how to properly use wildcards to aim for all versions without either getting it skipped or make fabric complain.