### PR TITLE
ViaVersion 5.2.1-SNAPSHOT

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -2,7 +2,7 @@
 org.gradle.jvmargs=-Xms32M -Xmx4G -XX:+UseG1GC -XX:+UseStringDeduplication
 
 loader_version=0.16.9
-viaver_version=5.2.0
+viaver_version=5.2.1-SNAPSHOT
 
 publish_mc_versions=1.21.4, 1.20.6, 1.20.4, 1.20.1, 1.19.4, 1.18.2, 1.17.1, 1.16.5, 1.15.2, 1.14.4
 # example: 1.19.1-rc1. Can be a blank value


### PR DESCRIPTION
So that the "snapshot jars only" rule is followed.