### PR TITLE
Revert JVMDowngrader to 1.0.1

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -14,7 +14,7 @@ plugins {
     id "com.modrinth.minotaur" version "2.8.7"
     id "fabric-loom" version "1.9-SNAPSHOT" apply false
     id "com.github.ben-manes.versions" version "0.51.0"
-    id "xyz.wagyourtail.jvmdowngrader" version "1.2.1"
+    id "xyz.wagyourtail.jvmdowngrader" version "1.0.1"
 }
 
 def ENV = System.getenv()


### PR DESCRIPTION
1.1.0 and newer completely break ViaVersion's Java8 downgraded JAR and therefore should not be used until a fix is provided by library dev - Crash can be observed [here](https://pastebin.com/raw/yWiHwQSR).