### PR TITLE
Drop support for JitPack

### DIFF
--- a/jitpack.yml
+++ b/jitpack.yml
@@ -1,7 +1,0 @@
-# Deploys the latest stable JDK 21 available and sets it to default without having to manually specify it here,
-# Which includes using temurin as the distribution.
-before_install:
-  - curl -s "https://get.sdkman.io" | bash
-  - source ~/.sdkman/bin/sdkman-init.sh
-  - sdk install java 21.0.5-tem
-  - sdk use java 21.0.5-tem


### PR DESCRIPTION
Drops support for Jitpack because of the following reasons:

1. ViaFabric exists on both GitHub actions and the [Jenkins service](https://ci.viaversion.com/view/All/job/ViaFabric),
2. Jitpack has to be constantly updated manually as there is no bot specifically designed for it,
3. We have maven central for a super while now and is the recommended route when using Gradle.

The URL itself in the build file will remain up *(for now)* as it is the only source where ClientCommands is available at.