### PR TITLE
Loom 1.10+ and versions 0.52.0

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -2,8 +2,8 @@ plugins {
     id("java")
     id("maven-publish")
     id("org.ajoberstar.grgit") version "5.3.0"
-    id("fabric-loom") version "1.9-SNAPSHOT"
-    id("com.github.ben-manes.versions") version "0.51.0"
+    id("fabric-loom") version "1.10-SNAPSHOT"
+    id("com.github.ben-manes.versions") version "0.52.0"
     id("xyz.wagyourtail.jvmdowngrader") version "0.7.1"
     id("me.modmuss50.mod-publish-plugin") version "0.8.4"
 }


### PR DESCRIPTION
1. Updates Fabric Loom to 1.10+, See release notes [here](https://github.com/FabricMC/fabric-loom/releases/tag/1.10),
2. Updates `versions` dependency to 0.52.0 which improves Kotlin 2.x compatibility. *(if kotlin was ever used)*