### PR TITLE
Sync version ping translation to all languages

### DIFF
--- a/src/main/resources/assets/viafabric/lang/de_de.json
+++ b/src/main/resources/assets/viafabric/lang/de_de.json
@@ -7,7 +7,7 @@
   "gui.viafabric_config.title": "ViaFabric-Konfigurationen",
   "gui.client_side.enable": "Clientseitig aktivieren",
   "gui.client_side.disable": "Clientseitig deaktivieren",
-  "gui.ping_version.translated": "VIA: %s",
+  "gui.ping_version.translated": "VIA: %s (%s)",
   "gui.hide_via_button.enable": "VIA Button ausblenden",
   "gui.hide_via_button.disable": "VIA Button anzeigen",
   "gui.via_button": "VIA"

--- a/src/main/resources/assets/viafabric/lang/es_es.json
+++ b/src/main/resources/assets/viafabric/lang/es_es.json
@@ -7,7 +7,7 @@
   "gui.viafabric_config.title": "Configuraciones de ViaFabric",
   "gui.client_side.enable": "Activar el lado del cliente",
   "gui.client_side.disable": "Desactivar el lado del cliente",
-  "gui.ping_version.translated": "VIA: %s",
+  "gui.ping_version.translated": "VIA: %s (%s)",
   "gui.hide_via_button.enable": "Ocultar el botón VIA",
   "gui.hide_via_button.disable": "Mostrar el botón VIA",
   "gui.via_button": "VIA"

--- a/src/main/resources/assets/viafabric/lang/et_ee.json
+++ b/src/main/resources/assets/viafabric/lang/et_ee.json
@@ -7,7 +7,7 @@
   "gui.viafabric_config.title": "ViaFabricu seadistused",
   "gui.client_side.enable": "Luba kliendipoolne",
   "gui.client_side.disable": "Keela kliendipoolne",
-  "gui.ping_version.translated": "VIA: %s",
+  "gui.ping_version.translated": "VIA: %s (%s)",
   "gui.hide_via_button.enable": "Peida VIA nupp",
   "gui.hide_via_button.disable": "Kuva VIA nuppu",
   "gui.via_button": "VIA"

--- a/src/main/resources/assets/viafabric/lang/fr_fr.json
+++ b/src/main/resources/assets/viafabric/lang/fr_fr.json
@@ -7,7 +7,7 @@
   "gui.viafabric_config.title": "Configuration de ViaFabric",
   "gui.client_side.enable": "Activer coté client",
   "gui.client_side.disable": "Désactiver coté client",
-  "gui.ping_version.translated": "VIA: %s",
+  "gui.ping_version.translated": "VIA: %s (%s)",
   "gui.hide_via_button.enable": "Cacher le bouton VIA",
   "gui.hide_via_button.disable": "Montrer le bouton VIA",
   "gui.via_button": "VIA"

--- a/src/main/resources/assets/viafabric/lang/hi_in.json
+++ b/src/main/resources/assets/viafabric/lang/hi_in.json
@@ -7,7 +7,7 @@
   "gui.viafabric_config.title": "ViaFabric कॉन्फ़िगरेशन",
   "gui.client_side.enable": "क्लाइंट साइड पर चालू करें",
   "gui.client_side.disable": "क्लाइंट साइड पर बंद करें",
-  "gui.ping_version.translated": "VIA: %s",
+  "gui.ping_version.translated": "VIA: %s (%s)",
   "gui.hide_via_button.enable": "VIA बटन छुपाएँ",
   "gui.hide_via_button.disable": "VIA बटन दिखाएँ",
   "gui.via_button": "VIA"

--- a/src/main/resources/assets/viafabric/lang/it_it.json
+++ b/src/main/resources/assets/viafabric/lang/it_it.json
@@ -7,7 +7,7 @@
   "gui.viafabric_config.title": "Configurazioni ViaFabric",
   "gui.client_side.enable": "Attivare lato cliente",
   "gui.client_side.disable": "Disattivare lato cliente",
-  "gui.ping_version.translated": "VIA: %s",
+  "gui.ping_version.translated": "VIA: %s (%s)",
   "gui.hide_via_button.enable": "Nascondi il pulsante VIA",
   "gui.hide_via_button.disable": "Mostra il pulsante VIA",
   "gui.via_button": "VIA"

--- a/src/main/resources/assets/viafabric/lang/ja_jp.json
+++ b/src/main/resources/assets/viafabric/lang/ja_jp.json
@@ -7,7 +7,7 @@
   "gui.viafabric_config.title": "ViaFabricの構成",
   "gui.client_side.enable": "クライアント側を有効にする",
   "gui.client_side.disable": "クライアント側を無効にする",
-  "gui.ping_version.translated": "VIA: %s",
+  "gui.ping_version.translated": "VIA: %s (%s)",
   "gui.hide_via_button.enable": "VIAボタンを隠す",
   "gui.hide_via_button.disable": "VIAボタンを表示",
   "gui.via_button": "VIA"

--- a/src/main/resources/assets/viafabric/lang/nl_nl.json
+++ b/src/main/resources/assets/viafabric/lang/nl_nl.json
@@ -7,7 +7,7 @@
   "gui.viafabric_config.title": "ViaFabric-configuraties",
   "gui.client_side.enable": "Klantenservice inschakelen",
   "gui.client_side.disable": "Cliëntenservice uitschakelen",
-  "gui.ping_version.translated": "VIA: %s",
+  "gui.ping_version.translated": "VIA: %s (%s)",
   "gui.hide_via_button.enable": "VIA-knop verbergen",
   "gui.hide_via_button.disable": "Toon VIA-knop",
   "gui.via_button": "VIA"

--- a/src/main/resources/assets/viafabric/lang/pl_pl.json
+++ b/src/main/resources/assets/viafabric/lang/pl_pl.json
@@ -7,7 +7,7 @@
   "gui.viafabric_config.title": "Konfiguracje ViaFabric",
   "gui.client_side.enable": "Włączenie po stronie klienta",
   "gui.client_side.disable": "Wyłączenie po stronie klienta",
-  "gui.ping_version.translated": "VIA: %s",
+  "gui.ping_version.translated": "VIA: %s (%s)",
   "gui.hide_via_button.enable": "Ukrycie przycisku VIA",
   "gui.hide_via_button.disable": "Pokaż przycisk VIA",
   "gui.via_button": "VIA"

--- a/src/main/resources/assets/viafabric/lang/pt_br.json
+++ b/src/main/resources/assets/viafabric/lang/pt_br.json
@@ -7,7 +7,7 @@
   "gui.viafabric_config.title": "Configurações de ViaFabric",
   "gui.client_side.enable": "Habilitar modo cliente",
   "gui.client_side.disable": "Desativar modo cliente",
-  "gui.ping_version.translated": "VIA: %s",
+  "gui.ping_version.translated": "VIA: %s (%s)",
   "gui.hide_via_button.enable": "Esconder botão VIA",
   "gui.hide_via_button.disable": "Mostrar botão VIA",
   "gui.via_button": "VIA"

--- a/src/main/resources/assets/viafabric/lang/ru_ru.json
+++ b/src/main/resources/assets/viafabric/lang/ru_ru.json
@@ -7,7 +7,7 @@
   "gui.viafabric_config.title": "Конфигурации ViaFabric",
   "gui.client_side.enable": "Включить на стороне клиента",
   "gui.client_side.disable": "Отключить на стороне клиента",
-  "gui.ping_version.translated": "VIA: %s",
+  "gui.ping_version.translated": "VIA: %s (%s)",
   "gui.hide_via_button.enable": "Скрыть кнопку VIA",
   "gui.hide_via_button.disable": "Показать кнопку VIA",
   "gui.via_button": "VIA"

--- a/src/main/resources/assets/viafabric/lang/tr_tr.json
+++ b/src/main/resources/assets/viafabric/lang/tr_tr.json
@@ -7,7 +7,7 @@
   "gui.viafabric_config.title": "ViaFabric Konfigürasyonu",
   "gui.client_side.enable": "Alıcı-tarafı aktive et",
   "gui.client_side.disable": "Alıcı-tarafı devre dışı bırak",
-  "gui.ping_version.translated": "VIA: %s",
+  "gui.ping_version.translated": "VIA: %s (%s)",
   "gui.hide_via_button.enable": "VIA tuşunu gizle",
   "gui.hide_via_button.disable": "VIA tuşunu göster",
   "gui.via_button": "VIA"

--- a/src/main/resources/assets/viafabric/lang/zh_cn.json
+++ b/src/main/resources/assets/viafabric/lang/zh_cn.json
@@ -7,7 +7,7 @@
   "gui.viafabric_config.title": "ViaFabric 配置",
   "gui.client_side.enable": "启用客户端模式",
   "gui.client_side.disable": "禁用客户端模式",
-  "gui.ping_version.translated": "转换为：%s（%s）",
+  "gui.ping_version.translated": "VIA: %s (%s)",
   "gui.hide_via_button.enable": "隐藏 VIA 按钮",
   "gui.hide_via_button.disable": "显示 VIA 按钮",
   "gui.via_button": "VIA"

--- a/src/main/resources/assets/viafabric/lang/zh_hk.json
+++ b/src/main/resources/assets/viafabric/lang/zh_hk.json
@@ -7,7 +7,7 @@
   "gui.viafabric_config.title": "ViaFabric 配置",
   "gui.client_side.enable": "啟用客戶端模式",
   "gui.client_side.disable": "禁用客戶端模式",
-  "gui.ping_version.translated": "轉換為：%s（%s）",
+  "gui.ping_version.translated": "VIA: %s (%s)",
   "gui.hide_via_button.enable": "隱藏 VIA 按鈕",
   "gui.hide_via_button.disable": "顯示 VIA 按鈕",
   "gui.via_button": "VIA"

--- a/src/main/resources/assets/viafabric/lang/zh_tw.json
+++ b/src/main/resources/assets/viafabric/lang/zh_tw.json
@@ -7,7 +7,7 @@
   "gui.viafabric_config.title": "ViaFabric 配置",
   "gui.client_side.enable": "啟用用戶端模式",
   "gui.client_side.disable": "禁用用戶端模式",
-  "gui.ping_version.translated": "轉換為：%s（%s）",
+  "gui.ping_version.translated": "VIA: %s (%s)",
   "gui.hide_via_button.enable": "隱藏 VIA 按鈕",
   "gui.hide_via_button.disable": "顯示 VIA 按鈕",
   "gui.via_button": "VIA"


### PR DESCRIPTION
Makes the version ping translation string consistent for all languages and also corrects it in the chinese language files.

`gui.enable_client_side.warning` on other hand would need to be corrected as it was changed in en_US.