### PR TITLE
Fabric API is required for mod to function

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -157,10 +157,10 @@ publishMods {
         type = BETA // alpha is hidden by default
 
         javaVersions.addAll(
-            (8..22).map { JavaVersion.toVersion(it) }
+            (8..25).map { JavaVersion.toVersion(it) }
         )
         minecraftVersions.addAll(mcReleases)
-        optional("fabric-api")
+        requires("fabric-api")
         embeds("cotton-client-commands")
     }
     modrinth {
@@ -168,7 +168,7 @@ publishMods {
         projectId = "YlKdE5VK"
         type = ALPHA
         minecraftVersions.addAll(mcReleases)
-        optional("fabric-api")
+        requires("fabric-api")
         embeds("viaversion")
     }
 }


### PR DESCRIPTION
Title says it all but Fabric API is required for the mod to function properly, otherwise we will crash if it's not included.