### PR TITLE
Ubuntu AMD64, Use JDK 25 in Gradle for 26.x

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -5,7 +5,7 @@ permissions:
 
 jobs:
   build:
-    runs-on: ubuntu-24.04-arm
+    runs-on: ubuntu-24.04
     steps:
       - name: Checkout Repository
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # 6.0.2
@@ -13,11 +13,11 @@ jobs:
           persist-credentials: false
       - name: Set up Gradle
         uses: gradle/actions/setup-gradle@4d9f0ba0025fe599b4ebab900eb7f3a1d93ef4c2 # 5.0.0
-      - name: Set up JDK 21
+      - name: Set up JDK 25
         uses: actions/setup-java@f2beeb24e141e01a676f977032f5a29d81c9e27e # 5.1.0
         with:
           distribution: 'temurin'
-          java-version: 21
+          java-version: 25
           check-latest: true
       - name: Build with Gradle
         run: ./gradlew build

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -6,7 +6,7 @@ permissions:
 jobs:
   publish:
     if: github.repository_owner == 'ViaVersion'
-    runs-on: ubuntu-24.04-arm
+    runs-on: ubuntu-24.04
     steps:
       - name: Checkout Repository
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # 6.0.2
@@ -14,11 +14,11 @@ jobs:
           persist-credentials: false
       - name: Set up Gradle
         uses: gradle/actions/setup-gradle@4d9f0ba0025fe599b4ebab900eb7f3a1d93ef4c2 # 5.0.0
-      - name: Set up JDK 21
+      - name: Set up JDK 25
         uses: actions/setup-java@f2beeb24e141e01a676f977032f5a29d81c9e27e # 5.1.0
         with:
           distribution: 'temurin'
-          java-version: 21
+          java-version: 25
           check-latest: true
       - name: Build and Publish
         env:

--- a/.github/workflows/sync-crowdin.yml
+++ b/.github/workflows/sync-crowdin.yml
@@ -10,7 +10,7 @@ permissions:
 
 jobs:
   synchronize-with-crowdin:
-    runs-on: ubuntu-24.04-arm
+    runs-on: ubuntu-24.04
     steps:
       - name: Checkout Repository
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # 6.0.2


### PR DESCRIPTION
1. [Reverts the OS to AMD64 image](https://github.com/FlorianMichael/BaseProject/pull/49),
2. Bumps the JDK to 25 for Gradle as 26.x has dropped support for JDK 21.