### PR TITLE
fix AbstractProtocol byte stream interference

### DIFF
--- a/src/main/java/com/viaversion/fabric/common/protocol/ViaFabricProtocolBase.java
+++ b/src/main/java/com/viaversion/fabric/common/protocol/ViaFabricProtocolBase.java
@@ -70,6 +70,11 @@ public class ViaFabricProtocolBase<CU extends ClientboundPacketType, CM extends 
             }
         });
     }
+    
+    @Override
+    protected void registerConfigurationChangeHandlers() {
+        // Not for us
+    }
 
     @Override
     protected void applySharedRegistrations() {


### PR DESCRIPTION
fixes bug with AbstractProtocol inheriting registerConfigurationChangeHandlers() which messed with the byte stream. this might also fix [this issue](https://github.com/ViaVersion/ViaFabric/issues/468)