### PR TITLE
Do not apply fabric-api particle workaround when protocol versions match

### DIFF
--- a/src/main/java/com/viaversion/fabric/common/protocol/ViaFabricProtocolBase.java
+++ b/src/main/java/com/viaversion/fabric/common/protocol/ViaFabricProtocolBase.java
@@ -19,11 +19,13 @@ package com.viaversion.fabric.common.protocol;
 
 import com.google.common.collect.Lists;
 import com.viaversion.fabric.common.AddressParser;
+import com.viaversion.fabric.common.platform.NativeVersionProvider;
 import com.viaversion.viaversion.api.Via;
 import com.viaversion.viaversion.api.protocol.AbstractProtocol;
 import com.viaversion.viaversion.api.protocol.packet.ClientboundPacketType;
 import com.viaversion.viaversion.api.protocol.packet.ServerboundPacketType;
 import com.viaversion.viaversion.api.protocol.packet.State;
+import com.viaversion.viaversion.api.protocol.version.ProtocolVersion;
 import com.viaversion.viaversion.api.type.Types;
 import com.viaversion.viaversion.protocols.base.ServerboundHandshakePackets;
 import com.viaversion.viaversion.util.Key;
@@ -54,9 +56,15 @@ public class ViaFabricProtocolBase<CU extends ClientboundPacketType, CM extends 
             return;
         }
 
+        final ProtocolVersion nativeServerVersion = Via.getManager().getProviders().get(NativeVersionProvider.class).getNativeServerProtocolVersion();
+
         // Fixes an issue where the Fabric Particle API causes disconnects when both the client and server have the mod installed and both are 1.21.5+.
         // See https://github.com/ViaVersion/ViaFabric/issues/428
         registerServerbound(customPayload, wrapper -> {
+            // ViaVersion doesn't track the user state when the user uses the same version as the server.
+            final ProtocolVersion userVersion = wrapper.user().getProtocolInfo().protocolVersion();
+            if (nativeServerVersion.equalTo(userVersion)) return;
+
             final String channel = Key.namespaced(wrapper.passthrough(Types.STRING));
             if (channel.equals("minecraft:register") || channel.equals("minecraft:unregister")) {
                 final List<String> channels = Lists.newArrayList(new String(wrapper.passthrough(Types.SERVERBOUND_CUSTOM_PAYLOAD_DATA), StandardCharsets.UTF_8).split("\0"));


### PR DESCRIPTION
Fixes #485 